### PR TITLE
Adding `settings.ini` to PyPI source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile*
 docs/_site
 build
 dist
+.vscode

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,24 @@
+## Include List
+
+include README.md
+include LICENSE
+include settings.ini
+
+recursive-include statsforecast *
+
+
+## Exclude List
+
+exclude CONTRIBUTING.md
+exclude Makefile
+exclude environment.yml
+
+exclude .gitconfig
+exclude .gitignore
+exclude .gitmodules
+
+recursive-exclude .github *
+recursive-exclude docs *
+recursive-exclude examples *
+recursive-exclude experiments *
+recursive-exclude nbs *


### PR DESCRIPTION
The `setup.py` file reads in the config values from `settings.ini`. So, absence of `settings.ini` file in the source distribution (`*.tar.gz` file), leads to failure in installation of `statsforecast`.

- [x] Currently (`v0.3.0`) the PyPI source does not include the `settings.ini` file. This PR fixes that.  
  ![image](https://user-images.githubusercontent.com/10201242/155265816-ca5db453-1e4f-49f7-ba83-212eb9cd07e9.png)
- [ ] ~~Changes to `README.md` file~~:
	- [ ] ~~Fixed some of the formatting errors~~.
	- [ ] ~~Fixed some broken URLs~~.
      > The relative URLs do not render properly on PyPI. Converted them from relative to absolute URLs.
      ![image](https://user-images.githubusercontent.com/10201242/155265965-f5fac446-d164-49b1-8baf-7053ceeb4ab5.png)

---

Closes #24 
 