### PR TITLE
Add dependency hint for quick intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ pip install -e .
 
 ## 🧬 How to use
 
+The following example needs `ipython` and `matplotlib` as additional packages. If not installed, install it via your preferred method, e.g. `pip install ipython matplotlib`.
+
 ```python
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
The "how to use" section uses ipython and matplotlib which are not automatically installed with statsforecast. Therefore, it's recommendable to install both packages on top of it.