### PR TITLE
Don't reverse levels when computing lower prediction interval in sample

### DIFF
--- a/statsforecast/arima.py
+++ b/statsforecast/arima.py
@@ -2451,7 +2451,7 @@ class AutoARIMA:
 
             lo = pd.DataFrame(
                 fitted_values.values.reshape(-1, 1) - quantiles * se.reshape(-1, 1),
-                columns=[f'lo_{l}%' for l in reversed(_level)],
+                columns=[f'lo_{l}%' for l in _level],
             )
             hi = pd.DataFrame(
                 fitted_values.values.reshape(-1, 1) + quantiles * se.reshape(-1, 1),


### PR DESCRIPTION
Closes https://github.com/Nixtla/statsforecast/issues/150

Names of the levels which dictate the confidence intervals to compute were being reversed for the lower CI for within sample predictions with an `AutoARIMA()` model (see this issue https://github.com/Nixtla/statsforecast/issues/150). 

I have removed the `reversed()` call on the levels tuple which resolves the issue. Lower confidence intervals are now returned in the correct order. See the demo below and the demo in the issue to replicate the bug: 

```
In [1]: import pandas as pd
   ...: from statsforecast.arima import AutoARIMA
   ...:
   ...: df = pd.read_csv("https://auto-arima-results.s3.amazonaws.com/M4-Hourly.csv")
   ...: data = df.y.tail(50).values
   ...:
   ...: model = AutoARIMA().fit(data)
   ...: in_sample_preds = model.predict_in_sample(level=(50, 80, 95))
   ...:
   ...: print(in_sample_preds.tail(5))
   ...: print(in_sample_preds.apply(lambda x: x - in_sample_preds["mean"]).tail(5))
   ...:
          lo_50%        lo_80%        lo_95%          mean        hi_50%        hi_80%        hi_95%
45  28095.930499  27738.005787  27338.012634  28493.610840  28891.291182  29249.215894  29649.209047
46  26553.488552  26195.563840  25795.570687  26951.168894  27348.849235  27706.773947  28106.767100
47  25438.876434  25080.951721  24680.958568  25836.556775  26234.237116  26592.161828  26992.154982
48  24794.698166  24436.773454  24036.780300  25192.378507  25590.058848  25947.983560  26347.976714
49  24839.403239  24481.478526  24081.485373  25237.083580  25634.763921  25992.688633  26392.681787
        lo_50%      lo_80%       lo_95%  mean      hi_50%      hi_80%       hi_95%
45 -397.680341 -755.605053 -1155.598207   0.0  397.680341  755.605053  1155.598207
46 -397.680341 -755.605053 -1155.598207   0.0  397.680341  755.605053  1155.598207
47 -397.680341 -755.605053 -1155.598207   0.0  397.680341  755.605053  1155.598207
48 -397.680341 -755.605053 -1155.598207   0.0  397.680341  755.605053  1155.598207
49 -397.680341 -755.605053 -1155.598207   0.0  397.680341  755.605053  1155.598207
```