### PR TITLE
fixing the argument name for external regressors in the example notebook

### DIFF
--- a/nbs/examples/Getting_Started_with_Auto_Arima_and_ETS.ipynb
+++ b/nbs/examples/Getting_Started_with_Auto_Arima_and_ETS.ipynb
@@ -857,7 +857,7 @@
     "    n_jobs=-1\n",
     ")\n",
     "\n",
-    "Y_hat_df_xreg = model.forecast(horizon, X=xreg_test)\n",
+    "Y_hat_df_xreg = model.forecast(horizon, X_df=xreg_test)\n",
     "Y_hat_df_xreg = Y_hat_df_xreg.reset_index()"
    ]
   },
@@ -943,7 +943,7 @@
     "    n_jobs=-1\n",
     ")\n",
     "\n",
-    "Y_hat_df_bench = model.forecast(horizon, X=xreg_test)\n",
+    "Y_hat_df_bench = model.forecast(horizon, X_df=xreg_test)\n",
     "Y_hat_df_bench = Y_hat_df_bench.reset_index()"
    ]
   },


### PR DESCRIPTION
the example uses `X` while the current version uses `X_df`. Updated an example to reflect this.