### PR TITLE
fix: make logging config local to package

### DIFF
--- a/nbs/core.ipynb
+++ b/nbs/core.ipynb
@@ -72,10 +72,11 @@
    "outputs": [],
    "source": [
     "#| exporti\n",
-    "logging.basicConfig(\n",
-    "    format='%(asctime)s %(name)s %(levelname)s: %(message)s',\n",
-    "    datefmt='%Y-%m-%d %H:%M:%S',\n",
-    ")\n",
+    "if __name__ == '__main__':\n",
+    "    logging.basicConfig(\n",
+    "        format='%(asctime)s %(name)s %(levelname)s: %(message)s',\n",
+    "        datefmt='%Y-%m-%d %H:%M:%S',\n",
+    "    )\n",
     "logger = logging.getLogger(__name__)"
    ]
   },

--- a/statsforecast/core.py
+++ b/statsforecast/core.py
@@ -13,10 +13,11 @@ import numpy as np
 import pandas as pd
 
 # %% ../nbs/core.ipynb 5
-logging.basicConfig(
-    format='%(asctime)s %(name)s %(levelname)s: %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S',
-)
+if __name__ == '__main__':
+    logging.basicConfig(
+        format='%(asctime)s %(name)s %(levelname)s: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+    )
 logger = logging.getLogger(__name__)
 
 # %% ../nbs/core.ipynb 8


### PR DESCRIPTION
The core notebook created a logging config when the notebook was ran, but also when the generated `core.py` file was imported.
This prevented anyone who imports `statsforecast` from setting their own logging config in the most commonly used way.

More details in the linked issue.
Fixes Nixtla/statsforecast#275