### PR TITLE
[FEAT] Ignore jupyter notebooks as part of `languages`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nbs/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 nbs/** linguist-documentation
+experiments/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-nbs/* linguist-vendored
+nbs/** linguist-documentation


### PR DESCRIPTION
This PR allows to ignore jupyter notebooks in the language part of the repo:

<img width="419" alt="image" src="https://user-images.githubusercontent.com/10517170/205805947-a305c866-647c-41fb-911d-02e3f9a3fc9a.png">

Before the change, the language stats were,

<img width="478" alt="image" src="https://user-images.githubusercontent.com/10517170/205806131-9609bb1d-4371-42cd-8f1e-3c88447ee0fa.png">


After the change,


<img width="588" alt="image" src="https://user-images.githubusercontent.com/10517170/205806071-61175ef9-b251-4351-b75c-000f60d9600d.png">
