### PR TITLE
[FIX] update sklearn -> scikit-learn

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -18,7 +18,7 @@ status = 2
 requirements = matplotlib numba>=0.55.0 numpy>=1.21.6 pandas>=1.3.5 plotly scipy>=1.7.3 statsmodels>=0.13.2 tqdm plotly-resampler
 ray_requirements = ray protobuf>=3.15.3,<4.0.0
 fugue_requirements = fugue[ray]>=0.7.0
-dev_requirements = nbdev black mypy flake8 ray protobuf>=3.15.3,<4.0.0 fugue>=0.7.0 matplotlib neuralforecast pmdarima prophet sklearn dask[distributed]
+dev_requirements = nbdev black mypy flake8 ray protobuf>=3.15.3,<4.0.0 fugue>=0.7.0 matplotlib neuralforecast pmdarima prophet scikit-learn dask[distributed]
 nbs_path = nbs
 doc_path = _docs
 recursive = True


### PR DESCRIPTION
This PR replaces 'sklearn' by 'scikit-learn' in the `settings.ini` file. 

See https://github.com/Nixtla/statsforecast/actions/runs/3745458067/jobs/6359911501.