### PR TITLE
Fix links and typos in documentation

### DIFF
--- a/nbs/examples/Getting_Started_short.ipynb
+++ b/nbs/examples/Getting_Started_short.ipynb
@@ -153,7 +153,7 @@
    "source": [
     "We fit the model by instantiating a new `StatsForecast` object with its two required parameters:\n",
     "\n",
-    "* `models`: a list of models. Select the models you want from [models](../models.ipynb) and import them. For this example, we will use a `AutoARIMA` model. We set `seson_lenght` to 12 because we expect seasonal effects every 12 months. (See: [Seasonal periods](https://robjhyndman.com/hyndsight/seasonal-periods/))\n",
+    "* `models`: a list of models. Select the models you want from [models](../models.ipynb) and import them. For this example, we will use a `AutoARIMA` model. We set `season_length` to 12 because we expect seasonal effects every 12 months. (See: [Seasonal periods](https://robjhyndman.com/hyndsight/seasonal-periods/))\n",
     "\n",
     "* `freq`: a string indicating the frequency of the data. (See [panda's available frequencies](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases).)\n",
     "\n",
@@ -1747,7 +1747,7 @@
     ":::{.callout-tip}\n",
     "## Next Steps\n",
     "\n",
-    "* Build and end to end forecasting pipeline following best practices in [End to End Walkthrough](./Getting_Started_complete.qmd)\n",
+    "* Build and end to end forecasting pipeline following best practices in [End to End Walkthrough](./Getting_Started_complete.ipynb)\n",
     "* [Forecast millions of series](./ForecastingAtScale.ipynb) in a scalable cluster in the cloud using Spark and Nixtla\n",
     "* [Detect anomalies](./AnomalyDetection.ipynb) in your past observations\n",
     ":::"

--- a/nbs/sidebar.yml
+++ b/nbs/sidebar.yml
@@ -42,4 +42,4 @@ website:
         - examples/ETS_ray_m5.ipynb
       - section: Community
         contents:
-          - Contributing
+          - examples/Contributing.ipynb


### PR DESCRIPTION
This PR fixes some typos in documentation. 
This also fixes the broken link to the [Community](https://nixtla.github.io/statsforecast/examples/getting_started_short.html) tab in the left sidebar on the web page.