### PR TITLE
[FIX] Different results between forecast and fit/predict MSTL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
            cache-env: true
 
        - name: Install library with ray and dask
-         run: pip install ".[ray,dask]" pytest
+         run: pip install ".[dev]" pytest
 
        - name: Windows redis
          if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: nbdev_test --skip_file_re '(distributed|ets).*.ipynb' --pause 1.0
 
-  test-distributed:
+  test-integration:
      runs-on: ${{ matrix.os }}
      strategy:
        fail-fast: false

--- a/action_files/test_fit_predict.py
+++ b/action_files/test_fit_predict.py
@@ -1,0 +1,71 @@
+import pandas as pd
+
+from neuralforecast.utils import AirPassengersPanel
+from statsforecast import StatsForecast
+from statsforecast.models import (
+    AutoARIMA, AutoETS, AutoCES, AutoTheta,
+    MSTL, GARCH, ARCH, HistoricAverage,
+    Naive, RandomWalkWithDrift,
+    SeasonalNaive, WindowAverage, SeasonalWindowAverage,
+    ADIDA, CrostonClassic,
+    CrostonOptimized, CrostonSBA, IMAPA,
+    TSB
+)
+
+
+def test_fit_predict_parallel():
+    models = [
+        AutoARIMA(),
+        AutoETS(),
+        AutoCES(),
+        AutoTheta(),
+        MSTL(season_length=12),
+        GARCH(),
+        ARCH(), 
+        HistoricAverage(),
+        Naive(),
+        RandomWalkWithDrift(),
+        SeasonalNaive(season_length=12),
+        WindowAverage(window_size=12),
+        SeasonalWindowAverage(window_size=12, season_length=12),
+        ADIDA(),
+        CrostonClassic(),
+        CrostonOptimized(),
+        IMAPA(),
+        TSB(0.5, 0.5)
+    ]
+        
+    sf = StatsForecast(models=models, freq='D', n_jobs=-1)
+    df_fcst = sf.forecast(df=AirPassengersPanel[['unique_id', 'ds', 'y']], h=7)
+    sf.fit(df=AirPassengersPanel[['unique_id', 'ds', 'y']])
+    df_predict = sf.predict(h=7)
+    pd.testing.assert_frame_equal(df_fcst, df_predict)
+
+
+def test_fit_predict_sequential():
+    models = [
+        AutoARIMA(),
+        AutoETS(),
+        AutoCES(),
+        AutoTheta(),
+        MSTL(season_length=12),
+        GARCH(),
+        ARCH(), 
+        HistoricAverage(),
+        Naive(),
+        RandomWalkWithDrift(),
+        SeasonalNaive(season_length=12),
+        WindowAverage(window_size=12),
+        SeasonalWindowAverage(window_size=12, season_length=12),
+        ADIDA(),
+        CrostonClassic(),
+        CrostonOptimized(),
+        IMAPA(),
+        TSB(0.5, 0.5)
+    ]
+        
+    sf = StatsForecast(models=models, freq='D')
+    df_fcst = sf.forecast(df=AirPassengersPanel[['unique_id', 'ds', 'y']], h=7)
+    sf.fit(df=AirPassengersPanel[['unique_id', 'ds', 'y']])
+    df_predict = sf.predict(h=7)
+    pd.testing.assert_frame_equal(df_fcst, df_predict)

--- a/nbs/models.ipynb
+++ b/nbs/models.ipynb
@@ -7715,7 +7715,7 @@
     "            period=self.season_length\n",
     "        )\n",
     "        x_sa = self.model_[['trend', 'remainder']].sum(axis=1).values\n",
-    "        self.trend_forecaster = self.trend_forecaster.fit(y=x_sa, X=X)\n",
+    "        self.trend_forecaster = self.trend_forecaster.new().fit(y=x_sa, X=X)\n",
     "        return self\n",
     "        \n",
     "    def predict(\n",

--- a/statsforecast/models.py
+++ b/statsforecast/models.py
@@ -4209,7 +4209,7 @@ class MSTL(_TS):
         """
         self.model_ = mstl(x=y, period=self.season_length)
         x_sa = self.model_[["trend", "remainder"]].sum(axis=1).values
-        self.trend_forecaster = self.trend_forecaster.fit(y=x_sa, X=X)
+        self.trend_forecaster = self.trend_forecaster.new().fit(y=x_sa, X=X)
         return self
 
     def predict(


### PR DESCRIPTION
This PR fixes #443. It also includes a new test to check the same results between `forecast` and `fit` and then `predict`.