### PR TITLE
Fix incorrect parameter name in How-To-Guides

### DIFF
--- a/nbs/docs/how-to-guides/00_Automatic_Forecasting.ipynb
+++ b/nbs/docs/how-to-guides/00_Automatic_Forecasting.ipynb
@@ -117,7 +117,7 @@
    "outputs": [],
    "source": [
     "# Generate forecasts for the specified horizon using the sf object\n",
-    "Y_hat_df = sf.forecast(df=Y_df, horizon=horizon) # forecast data\n",
+    "Y_hat_df = sf.forecast(df=Y_df, h=horizon) # forecast data\n",
     "\n",
     "# Display the first few rows of the forecast DataFrame\n",
     "Y_hat_df.head() # preview of forecasted data"


### PR DESCRIPTION
If I am correct, the parameter for defining forecast horizon in [`StatsForecast.forecast`](https://nixtla.github.io/statsforecast/src/core/core.html#statsforecast.forecast) should be `h` instead of `horizon`. 

This small fix ensures that the function call aligns with the correct usage.