### PR TITLE
automatically cancel stale checks per branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,10 @@ defaults:
   run:
     shell: bash -l {0}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nb-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the concurrency configuration to the CI so that if a PR gets a new commit pushed the previous checks are canceled, which will reduce our overall usage and prevent reaching limit quotas.

[Reference](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow)