### PR TITLE
add no response bot

### DIFF
--- a/.github/workflows/no-response.yaml
+++ b/.github/workflows/no-response.yaml
@@ -1,0 +1,21 @@
+name: No Response Bot
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          closeComment: >
+              This issue has been automatically closed because it has been awaiting a response for too long.
+              When you have time to to work with the maintainers to resolve this issue, please post a new comment and it will be re-opened.
+              If the issue has been locked for editing by the time you return to it, please open a new issue and reference this one.
+          daysUntilClose: 30
+          responseRequiredLabel: awaiting response
+          token: ${{ github.token }}


### PR DESCRIPTION
Adds a bot that will run everyday, look for issues with the "awaiting response" label and will automatically close them if they haven't had any comments from the author in 30 days. In case the author comments before this time it will remove the label. This will help us automatically close issues that have probably been solved but the author didn't close them.