### PR TITLE
fix arima max order params

### DIFF
--- a/nbs/src/arima.ipynb
+++ b/nbs/src/arima.ipynb
@@ -2769,7 +2769,7 @@
     "    nonmissing_idxs = np.where(~missing)[0]\n",
     "    firstnonmiss = nonmissing_idxs.min()\n",
     "    lastnonmiss = nonmissing_idxs.max()\n",
-    "    series_len = np.sum(~missing[firstnonmiss:lastnonmiss])\n",
+    "    series_len = int(np.sum(~missing[firstnonmiss:lastnonmiss]))\n",
     "    x = x[firstnonmiss:]\n",
     "    if xreg is not None:\n",
     "        if xreg.dtype not in (np.float32, np.float64):\n",
@@ -3180,6 +3180,21 @@
     "    bestfit['lambda'] = blambda\n",
     "    \n",
     "    return bestfit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60d140d0-b4bd-4773-8723-ec47d591def5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "assert math.isclose(\n",
+    "    auto_arima_f(np.arange(1, 3))['coef']['intercept'],\n",
+    "    1.5,\n",
+    "    rel_tol=1e-3,\n",
+    ")"
    ]
   },
   {

--- a/statsforecast/arima.py
+++ b/statsforecast/arima.py
@@ -1813,7 +1813,7 @@ def auto_arima_f(
     nonmissing_idxs = np.where(~missing)[0]
     firstnonmiss = nonmissing_idxs.min()
     lastnonmiss = nonmissing_idxs.max()
-    series_len = np.sum(~missing[firstnonmiss:lastnonmiss])
+    series_len = int(np.sum(~missing[firstnonmiss:lastnonmiss]))
     x = x[firstnonmiss:]
     if xreg is not None:
         if xreg.dtype not in (np.float32, np.float64):
@@ -2301,11 +2301,11 @@ def auto_arima_f(
 
     return bestfit
 
-# %% ../nbs/src/arima.ipynb 88
+# %% ../nbs/src/arima.ipynb 89
 def forward_arima(fitted_model, y, xreg=None, method="CSS-ML"):
     return Arima(x=y, model=fitted_model, xreg=xreg, method=method)
 
-# %% ../nbs/src/arima.ipynb 97
+# %% ../nbs/src/arima.ipynb 98
 def print_statsforecast_ARIMA(model, digits=3, se=True):
     print(arima_string(model, padding=False))
     if model["lambda"] is not None:
@@ -2335,7 +2335,7 @@ def print_statsforecast_ARIMA(model, digits=3, se=True):
     if not np.isnan(model["aic"]):
         print(f'AIC={round(model["aic"], 2)}')
 
-# %% ../nbs/src/arima.ipynb 99
+# %% ../nbs/src/arima.ipynb 100
 class ARIMASummary:
     """ARIMA Summary."""
 
@@ -2348,7 +2348,7 @@ class ARIMASummary:
     def summary(self):
         return print_statsforecast_ARIMA(self.model)
 
-# %% ../nbs/src/arima.ipynb 100
+# %% ../nbs/src/arima.ipynb 101
 class AutoARIMA:
     """An AutoARIMA estimator.
 


### PR DESCRIPTION
The `max_p` and `max_q` parameters are set using the series length, which is computed using `numpy.sum` and returns a `numpy.int64`. However, there's a later check to verify that these parameters are `int`, which can fail for short series, see for example https://github.com/Nixtla/statsforecast/issues/602#issuecomment-1684335432.

This ensures that the series length is a python int, so that those parameters are python ints as well.