### PR TITLE
redirect to mintlify docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -14,9 +14,14 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Clone repo
+        uses: actions/checkout@v3
+      - name: Clone docs repo
+        uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          repository: Nixtla/docs
+          ref: scripts
+          path: docs-scripts
       - uses: actions/setup-python@v4
         with:
           cache: "pip"
@@ -46,7 +51,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: docs
           publish_dir: ./_docs
-          # The following lines assign commit authorship to the official GH-Actions bot for deploys to `docs` branch.
-          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Configure redirects for gh-pages
+        run: python docs-scripts/configure-redirects.py statsforecast
+      - name: Deploy to Github Pages
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./gh-pages
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,0 @@
-name: Deploy to GitHub Pages
-on:
-  push:
-    branches: ["main"]
-  workflow_dispatch:
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps: [uses: fastai/workflows/quarto-ghp@master]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs-scripts"]
-	path = docs-scripts
-	url = https://github.com/Nixtla/docs.git
-	branch = scripts

--- a/settings.ini
+++ b/settings.ini
@@ -20,7 +20,7 @@ ray_requirements = fugue[ray]>=0.8.1 protobuf>=3.15.3,<4.0.0
 dask_requirements = fugue[dask]>=0.8.1
 spark_requirements = fugue[spark]>=0.8.1
 plotly_requirements = plotly plotly-resampler
-dev_requirements = nbdev black mypy flake8 ray protobuf>=3.15.3,<4.0.0 matplotlib pmdarima prophet scikit-learn fugue[dask,ray,spark]>=0.8.1 datasetsforecast supersmoother nbdev_plotly
+dev_requirements = nbdev black mypy flake8 ray<2.8 protobuf>=3.15.3,<4.0.0 matplotlib pmdarima prophet scikit-learn fugue[dask,ray,spark]>=0.8.1 datasetsforecast supersmoother nbdev_plotly
 nbs_path = nbs
 doc_path = _docs
 recursive = True


### PR DESCRIPTION
Makes the documentation at https://nixtla.github.io/statsforecast redirect to https://nixtla.mintlify.app/statsforecast. Also replaces the submodule Nixtla/docs with a checkout.

Also restricts ray to <2.8 because it seems like they have a mess with grpcio.