### PR TITLE
improve deprecation error messages

### DIFF
--- a/nbs/src/core/core.ipynb
+++ b/nbs/src/core/core.ipynb
@@ -838,9 +838,9 @@
     "#| exporti\n",
     "def _warn_df_constructor():\n",
     "    warnings.warn(\n",
-    "        \"The `df` argument of the StatsForecast constructor is deprecated \"\n",
-    "        \"and will be removed in a future version. \"\n",
-    "        \"Please pass `df` to the fit/forecast methods instead.\",\n",
+    "        \"The `df` argument of the StatsForecast constructor as well as reusing stored \"\n",
+    "        \"dfs from other methods is deprecated and will raise an error in a future version. \"\n",
+    "        \"Please provide the `df` argument to the corresponding method instead, e.g. fit/forecast.\",\n",
     "        category=DeprecationWarning,\n",
     "    )\n",
     "\n",
@@ -920,8 +920,7 @@
     "        self.freq = freq\n",
     "        self.n_jobs = n_jobs\n",
     "        self.fallback_model = fallback_model\n",
-    "        self.verbose = verbose \n",
-    "        self.n_jobs == 1\n",
+    "        self.verbose = verbose\n",
     "        if df is not None:\n",
     "            _warn_df_constructor()\n",
     "            self._prepare_fit(df=df, sort_df=sort_df)\n",
@@ -941,6 +940,8 @@
     "        sort_df: bool = True,\n",
     "    ) -> None:\n",
     "        if df is None:\n",
+    "            if not hasattr(self, 'ga'):\n",
+    "                raise ValueError('You must provide the `df` argument.')\n",
     "            _warn_df_constructor()\n",
     "            return\n",
     "        df = ensure_time_dtype(df, 'ds')\n",
@@ -1923,21 +1924,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50d26dc0-5cfa-4328-a7ba-227940204b40",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import statsforecast"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "229e3746-68d2-4038-8926-240ab1e08b9f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "statsforecast.config.id_as_index = False"
+    "sf_config.id_as_index = False"
    ]
   },
   {

--- a/statsforecast/core.py
+++ b/statsforecast/core.py
@@ -414,9 +414,9 @@ def _get_n_jobs(n_groups, n_jobs):
 # %% ../nbs/src/core/core.ipynb 27
 def _warn_df_constructor():
     warnings.warn(
-        "The `df` argument of the StatsForecast constructor is deprecated "
-        "and will be removed in a future version. "
-        "Please pass `df` to the fit/forecast methods instead.",
+        "The `df` argument of the StatsForecast constructor as well as reusing stored "
+        "dfs from other methods is deprecated and will raise an error in a future version. "
+        "Please provide the `df` argument to the corresponding method instead, e.g. fit/forecast.",
         category=DeprecationWarning,
     )
 
@@ -490,7 +490,6 @@ class _StatsForecast:
         self.n_jobs = n_jobs
         self.fallback_model = fallback_model
         self.verbose = verbose
-        self.n_jobs == 1
         if df is not None:
             _warn_df_constructor()
             self._prepare_fit(df=df, sort_df=sort_df)
@@ -512,6 +511,8 @@ class _StatsForecast:
         sort_df: bool = True,
     ) -> None:
         if df is None:
+            if not hasattr(self, "ga"):
+                raise ValueError("You must provide the `df` argument.")
             _warn_df_constructor()
             return
         df = ensure_time_dtype(df, "ds")


### PR DESCRIPTION
The deprecation message for not providing a df to one of the methods that needs it always referenced the constructor, but they'll also be printed if someone reuses a dataset built with another method, e.g. the following code
```python
sf = StatsForecast(models, freq)
sf.fit(df=df)
sf.forecast(h=2)
```
would show the deprecation warning about providing the df to the constructor, even though it wasn't provided to it. This changes the message slightly to suggest that the df may come from either the constructor or a previous method.

Also now raises an informative error if the df wasn't provided at all, e.g. the following code
```python
sf = StatsForecast(models, freq)
sf.fit()
```
would raise a confusing error about the StatsForecast object not having a `ga` attribute. This now asks for the `df` argument to be provided.