### PR TITLE
remove seasonal component in CES when data has less than two periods

### DIFF
--- a/nbs/src/ces.ipynb
+++ b/nbs/src/ces.ipynb
@@ -1116,7 +1116,7 @@
     "        raise ValueError('Invalid model type')\n",
     "\n",
     "    seasontype = model\n",
-    "    if m < 1 or len(y) <= m or m == 1:\n",
+    "    if m < 1 or len(y) < 2 * m or m == 1:\n",
     "        seasontype = 'N'\n",
     "    n = len(y)\n",
     "    npars = 2 \n",
@@ -1148,6 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "13cf85b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,6 +1208,19 @@
     "res_transfer = forward_ces(res, np.log(ap))\n",
     "for key in res_transfer['par']:\n",
     "    test_eq(res['par'][key], res_transfer['par'][key])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96d40dd1-672a-4f8d-b222-e4a3acc7af85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#| hide\n",
+    "# less than two seasonal periods removes seasonal component\n",
+    "res = auto_ces(np.arange(23, dtype=np.float64), m=12)\n",
+    "assert res['seasontype'] == 'N'"
    ]
   }
  ],

--- a/statsforecast/ces.py
+++ b/statsforecast/ces.py
@@ -747,7 +747,7 @@ def auto_ces(
         raise ValueError("Invalid model type")
 
     seasontype = model
-    if m < 1 or len(y) <= m or m == 1:
+    if m < 1 or len(y) < 2 * m or m == 1:
         seasontype = "N"
     n = len(y)
     npars = 2


### PR DESCRIPTION
Removes the seasonal component in CES when the data has less than two seasonal periods.

Fixes #577