### PR TITLE
set upper bound on pandas

### DIFF
--- a/dev/environment.yml
+++ b/dev/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib
   - numba>=0.55.0
   - numpy>=1.21.6
-  - pandas>=1.3.5
+  - pandas>=1.3.5,<2.2
   - pyspark>=3.3
   - pip
   - prophet


### PR DESCRIPTION
Ray is incompatible with pandas>=2.2 ([issue](https://discuss.ray.io/t/pandas-importerror-with-ray-data-dataset-show/13486)). This pins pandas to <2.2 while a fix is released.