### PR TITLE
specify conformal intervals restrictions with respect to series lengths in tutorial

### DIFF
--- a/nbs/docs/tutorials/ConformalPrediction.ipynb
+++ b/nbs/docs/tutorials/ConformalPrediction.ipynb
@@ -13622,6 +13622,8 @@
     "\n",
     "# Create a list of models and instantiation parameters \n",
     "intervals = ConformalIntervals(h=24, n_windows=2)\n",
+    "# P.S. n_windows*h should be less than the count of data elements in your time series sequence.\n",
+    "# P.S. Also value of n_windows should be atleast 2 or more.\n",
     "\n",
     "models = [\n",
     "    SeasonalExponentialSmoothing(season_length=24,alpha=0.1, prediction_intervals=intervals),\n",


### PR DESCRIPTION
Added note on arguments `n_windows` and `h`  passed to `ConformalIntervals` class. It is not mentioned anywhere in the documentation and can be a pain point for beginners.