### PR TITLE
fix matrix product for arima var_coef

### DIFF
--- a/nbs/src/arima.ipynb
+++ b/nbs/src/arima.ipynb
@@ -1339,7 +1339,7 @@
     "            A = arima_gradtrans(coef, arma)\n",
     "            A = A[np.ix_(mask, mask)]\n",
     "            sol = np.matmul(res.hess_inv, A) / n_used\n",
-    "            var = np.dot(A, sol)\n",
+    "            var = A.T @ sol\n",
     "            coef = arima_undopars(coef, arma)\n",
     "        else:\n",
     "            var = None if no_optim else res.hess_inv / n_used\n",

--- a/statsforecast/arima.py
+++ b/statsforecast/arima.py
@@ -1004,7 +1004,7 @@ def arima(
             A = arima_gradtrans(coef, arma)
             A = A[np.ix_(mask, mask)]
             sol = np.matmul(res.hess_inv, A) / n_used
-            var = np.dot(A, sol)
+            var = A.T @ sol
             coef = arima_undopars(coef, arma)
         else:
             var = None if no_optim else res.hess_inv / n_used


### PR DESCRIPTION
The [R code](https://github.com/wch/r-source/blob/ee6b426998d91cb1d4584ab11a707d9a37cb875f/src/library/stats/R/arima.R#L331) uses the [crossprod function](https://stat.ethz.ch/R-manual/R-patched/library/base/html/crossprod.html), which transposes the first argument before performing the matrix multiply.

Fixes #847
