### PR TITLE
remove TqdmExperimentalWarning

### DIFF
--- a/nbs/src/core/core.ipynb
+++ b/nbs/src/core/core.ipynb
@@ -101,7 +101,7 @@
     "import utilsforecast.processing as ufp\n",
     "from fugue.execution.factory import make_execution_engine, try_get_context_execution_engine\n",
     "from threadpoolctl import threadpool_limits\n",
-    "from tqdm.autonotebook import tqdm\n",
+    "from tqdm.auto import tqdm\n",
     "from triad import conditional_dispatcher\n",
     "from utilsforecast.compat import DataFrame, pl_DataFrame, pl_Series\n",
     "from utilsforecast.grouped_array import GroupedArray as BaseGroupedArray\n",

--- a/statsforecast/core.py
+++ b/statsforecast/core.py
@@ -27,7 +27,7 @@ from fugue.execution.factory import (
     try_get_context_execution_engine,
 )
 from threadpoolctl import threadpool_limits
-from tqdm.autonotebook import tqdm
+from tqdm.auto import tqdm
 from triad import conditional_dispatcher
 from utilsforecast.compat import DataFrame, pl_DataFrame, pl_Series
 from utilsforecast.grouped_array import GroupedArray as BaseGroupedArray


### PR DESCRIPTION
Changes the `tqdm` import from `tqdm.autonotebook` to `tqdm.auto` to remove the `TqdmExperimentalWarning`.