### PR TITLE
hotfix: Correct MSTL tutorial 

### DIFF
--- a/nbs/docs/models/MultipleSeasonalTrend.ipynb
+++ b/nbs/docs/models/MultipleSeasonalTrend.ipynb
@@ -3426,7 +3426,7 @@
     "from statsforecast.utils import ConformalIntervals\n",
     "horizon = len(test) # number of predictions\n",
     "\n",
-    "models = [MSTL(season_length=[24, 24*7], # seasonalities of the time series \n",
+    "models = [MSTL(season_length=[24, 168], # seasonalities of the time series \n",
     "trend_forecaster=AutoARIMA(prediction_intervals=ConformalIntervals(n_windows=3, h=horizon)))]"
    ]
   },


### PR DESCRIPTION
## Description 

Corrected `seasonal_length` in MSTL model after a user on Slack reported seeing unusual results for the prediction intervals. With this fix, intervals now look ok. Closes #887.