### PR TITLE
Asymmetric prediction intervals in ConformalIntervals class

### DIFF
--- a/nbs/src/core/models.ipynb
+++ b/nbs/src/core/models.ipynb
@@ -256,7 +256,7 @@
     "def _get_conformal_method(method: str):\n",
     "    available_methods = {\n",
     "        \"conformal_distribution\": _add_conformal_distribution_intervals,\n",
-    "        #\"conformal_error\": _add_conformal_error_intervals,\n",
+    "        #\\\"naive_error\\\": _add_naive_error_intervals,\\n\",\n",
     "    }\n",
     "    if method not in available_methods.keys():\n",
     "        raise ValueError(\n",

--- a/statsforecast/utils.py
+++ b/statsforecast/utils.py
@@ -336,7 +336,7 @@ class ConformalIntervals:
             raise ValueError(
                 "You need at least two windows to compute conformal intervals"
             )
-        allowed_methods = ["conformal_distribution"]
+        allowed_methods = ["conformal_distribution", "naive_error"]
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
         self.n_windows = n_windows


### PR DESCRIPTION
Conformal intervals compute a symmetric intervals of the forecasting error by computing the absolute value of its distribution. For some datasets, it is useful to have asymmetric intervals, like data with a skewed distribution.

We added the "naive_error" method for the ConformalIntervals class.

Minimum example:
```

import pandas as pd
from statsforecast import StatsForecast
from statsforecast.models import ZeroModel, Naive
from statsforecast.utils import ConformalIntervals
import matplotlib.pyplot as plt

df = pd.read_parquet('https://datasets-nixtla.s3.amazonaws.com/m4-hourly.parquet')
df = df.iloc[:748, :]

df['y'].iloc[:24*4].plot()
plt.show()
h=25
intervals = ConformalIntervals(h=h, n_windows=int((len(df)-1)/h), method='naive_error')
sf = StatsForecast(models=[Naive(prediction_intervals=intervals)], freq=1, n_jobs=1)
sf.fit(df=df)
preds = sf.predict(h=h, level=[50])
preds.iloc[:, 1:].plot()
plt.show()
```