### PR TITLE
Added err_step for prediction interval

### DIFF
--- a/action_files/test_conformal_predictions.py
+++ b/action_files/test_conformal_predictions.py
@@ -1,0 +1,22 @@
+import pytest
+import pandas as pd
+from statsforecast import StatsForecast
+from statsforecast.models import ZeroModel, Naive
+from statsforecast.utils import ConformalIntervals
+import matplotlib.pyplot as plt
+
+
+
+@pytest.mark.parametrize("unit_prediction_step", [True, False])
+def test_unit_prediction_step(unit_prediction_step):
+    df = pd.read_parquet('https://datasets-nixtla.s3.amazonaws.com/m4-hourly.parquet')
+    df = df.iloc[:748, :]
+
+    h = 24
+    steps = 1 if unit_prediction_step else h
+    intervals = ConformalIntervals(h=h, n_windows=int((len(df) - 1) / h))
+    sf = StatsForecast(models=[Naive(prediction_intervals=intervals, err_step=steps)], freq=1, n_jobs=1)
+    sf.fit(df=df)
+    preds = sf.predict(h=h, level=[50])
+    preds.iloc[:, 2:].plot()
+    plt.show()

--- a/nbs/src/core/models.ipynb
+++ b/nbs/src/core/models.ipynb
@@ -256,7 +256,7 @@
     "def _get_conformal_method(method: str):\n",
     "    available_methods = {\n",
     "        \"conformal_distribution\": _add_conformal_distribution_intervals,\n",
-    "        #\\\"naive_error\\\": _add_naive_error_intervals,\\n\",\n",
+    "        #\\\"conformal_error\\\": _add_conformal_error_intervals,\\n\",\n",
     "    }\n",
     "    if method not in available_methods.keys():\n",
     "        raise ValueError(\n",

--- a/nbs/src/core/models.ipynb
+++ b/nbs/src/core/models.ipynb
@@ -256,7 +256,7 @@
     "def _get_conformal_method(method: str):\n",
     "    available_methods = {\n",
     "        \"conformal_distribution\": _add_conformal_distribution_intervals,\n",
-    "        #\"conformal_error\": _add_conformal_error_intervals,\n",
+    "        #\\\"naive_error\\\": _add_naive_error_intervals,\\n\",\n",
     "    }\n",
     "    if method not in available_methods.keys():\n",
     "        raise ValueError(\n",

--- a/statsforecast/utils.py
+++ b/statsforecast/utils.py
@@ -336,7 +336,7 @@ class ConformalIntervals:
             raise ValueError(
                 "You need at least two windows to compute conformal intervals"
             )
-        allowed_methods = ["conformal_distribution", "naive_error"]
+        allowed_methods = ["conformal_distribution"]
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
         self.n_windows = n_windows

--- a/statsforecast/utils.py
+++ b/statsforecast/utils.py
@@ -336,7 +336,7 @@ class ConformalIntervals:
             raise ValueError(
                 "You need at least two windows to compute conformal intervals"
             )
-        allowed_methods = ["conformal_distribution"]
+        allowed_methods = ["conformal_distribution", "naive_error"]
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
         self.n_windows = n_windows


### PR DESCRIPTION
The prediction intervals via ConformalPrediction are obtained by retrieving errors on the training set by a sliding window with the same spacing of the number of forecasted steps ahead. If the number of steps ahead is a multiple of the seasonality of the forecasted signal, and the forecaster is applied at any different timestep w.r.t. the one used to obtain the error intervals in the first place, this leads to unreliable prediction intervals. 

To prevent this, I added the err_step argument to all the models, which can be used to specify the step of the sliding window when retrieving the errors

A minimum example with plots is shown in `action_files/test_conformal_predictions.py` 

![plt_2](https://github.com/user-attachments/assets/9cc56f37-5e8c-4e81-8fd0-fd5a94f3bd7e)
![plt_1](https://github.com/user-attachments/assets/90fc87f2-170f-4abd-b375-91d4208438c0)
