### PR TITLE
static build requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,8 @@ all_requirements = [
     *plotly_requirements,
     *polars_requirements,
     *dev_requirements,
+    *ray_requirements,
 ]
-if sys.version_info < (3, 12):
-    all_requirements.extend(ray_requirements)
 
 ext_modules = [
     Pybind11Extension(


### PR DESCRIPTION
so that metadata is the same in all distributions

perhaps a pipeline is about to show me why you didn't do it like this all along, but it seems strange...