### PR TITLE
Feature/cpp arima cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ ext_modules = [
         name="statsforecast._lib",
         sources=glob.glob("src/*.cpp"),
         include_dirs=["include/statsforecast", "external_libs/eigen"],
-        cxx_std=17,
+        cxx_std=20,
     )
 ]
 ParallelCompile("CMAKE_BUILD_PARALLEL_LEVEL", needs_recompile=naive_recompile).install()

--- a/src/arima.cpp
+++ b/src/arima.cpp
@@ -10,6 +10,18 @@
 
 namespace arima {
 namespace py = pybind11;
+namespace {
+template <typename T> std::span<T> make_span(py::array_t<T> &array) {
+  // ssize_t to size_t is safe because the size of an array is non-negative
+  return {array.mutable_data(), static_cast<size_t>(array.size())};
+}
+
+template <typename T>
+std::span<const T> make_cspan(const py::array_t<T> &array) {
+  // ssize_t to size_t is safe because the size of an array is non-negative
+  return {array.data(), static_cast<size_t>(array.size())};
+}
+} // namespace
 
 void partrans(int p, const double *raw, double *newv) {
   std::transform(raw, raw + p, newv, [](double x) { return std::tanh(x); });
@@ -502,10 +514,10 @@ py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
   assert(armav.ndim() == 1);
 
   constexpr double eps = 1e-3;
-  const std::span arma(armav.data(), armav.size());
-  const std::span x(xv.data(), xv.size());
-
+  const auto arma = make_cspan(armav);
+  const auto x = make_cspan(xv);
   const size_t n = x.size();
+
   const int mp = arma[0];
   const int mq = arma[1];
   const int msp = arma[2];
@@ -513,9 +525,10 @@ py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
   std::array<double, 100> w1;
   std::array<double, 100> w2;
   std::array<double, 100> w3;
+  assert(mp < 100);
 
   py::array_t<double> outv({n, n});
-  auto out = outv.mutable_data();
+  const auto out = make_span(outv);
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = 0; j < n; ++j) {
       out[i * n + j] = (i == j) ? 1.0 : 0.0;
@@ -524,11 +537,11 @@ py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
 
   if (mp > 0) {
     std::copy(x.begin(), x.begin() + mp, w1.begin());
-    partrans(mp, w1, w2);
+    partrans(mp, w1.data(), w2.data());
 
     for (size_t i = 0; i < mp; ++i) {
       w1[i] += eps;
-      partrans(mp, w1, w3);
+      partrans(mp, w1.data(), w3.data());
 
       for (size_t j = 0; j < mp; ++j) {
         out[n * i + j] = (w3[j] - w2[j]) / eps;
@@ -576,20 +589,29 @@ py::array_t<double> arima_undopars(const py::array_t<double> xv,
   return outv;
 }
 
-void invpartrans(int p, const py::array_t<double> phiv,
+void invpartrans(const int p, const py::array_t<double> phiv,
                  py::array_t<double> outv) {
-  auto phi = phiv.data();
-  auto out = outv.mutable_data();
-  std::copy(phi, phi + p, out);
-  std::vector<double> work(phi, phi + p);
-  for (int j = p - 1; j > 0; --j) {
-    double a = out[j];
-    for (int k = 0; k < j; ++k) {
+  assert(p >= 0);
+  assert(phiv.ndim() == 1);
+  assert(outv.ndim() == 1);
+  assert(p <= phiv.size());
+  assert(p <= outv.size());
+
+  const auto phi = make_cspan(phiv);
+  const auto out = make_span(outv);
+
+  std::copy(phi.begin(), phi.begin() + p, out.begin());
+
+  std::vector<double> work(phi.begin(), phi.begin() + p);
+  for (size_t j = p - 1; j > 0; --j) {
+    const double a = out[j];
+    for (size_t k = 0; k < j; ++k) {
       work[k] = (out[k] + a * out[j - k - 1]) / (1 - a * a);
     }
-    std::copy(work.begin(), work.begin() + j, out);
+    std::copy(work.begin(), work.begin() + j, out.begin());
   }
-  for (int j = 0; j < p; ++j) {
+
+  for (size_t j = 0; j < p; ++j) {
     out[j] = std::atanh(out[j]);
   }
 }

--- a/src/arima.cpp
+++ b/src/arima.cpp
@@ -23,7 +23,7 @@ std::span<const T> make_cspan(const py::array_t<T> &array) {
 }
 } // namespace
 
-void partrans(const size_t p, const std::span<const double> rawv,
+void partrans(const uint32_t p, const std::span<const double> rawv,
               const std::span<double> newv) {
   assert(p <= rawv.size());
   assert(p <= newv.size());
@@ -42,25 +42,20 @@ void partrans(const size_t p, const std::span<const double> rawv,
 
 std::tuple<py::array_t<double>, py::array_t<double>>
 arima_transpar(const py::array_t<double> params_inv,
-               const py::array_t<int> armav, bool trans) {
+               const py::array_t<uint32_t> armav, bool trans) {
   assert(params_inv.ndim() == 1);
   assert(armav.ndim() == 1);
 
   const auto arma = make_cspan(armav);
   const auto params_in = make_cspan(params_inv);
 
-  const int mp = arma[0];
-  const int mq = arma[1];
-  const int msp = arma[2];
-  const int msq = arma[3];
-  const int ns = arma[4];
-  assert(mp >= 0);
-  assert(mq >= 0);
-  assert(msp >= 0);
-  assert(msq >= 0);
-  assert(ns >= 0);
-  const int p = mp + ns * msp;
-  const int q = mq + ns * msq;
+  const uint32_t mp = arma[0];
+  const uint32_t mq = arma[1];
+  const uint32_t msp = arma[2];
+  const uint32_t msq = arma[3];
+  const uint32_t ns = arma[4];
+  const uint32_t p = mp + ns * msp;
+  const uint32_t q = mq + ns * msq;
 
   std::vector<double> params(params_in.begin(), params_in.end());
 
@@ -73,7 +68,7 @@ arima_transpar(const py::array_t<double> params_inv,
     if (mp > 0) {
       partrans(mp, params_in, params);
     }
-    int v = mp + mq;
+    const uint32_t v = mp + mq;
     if (msp > 0) {
       partrans(msp, params_in.subspan(v), std::span(params).subspan(v));
     }
@@ -531,7 +526,7 @@ void getQ0(const py::array_t<double> phiv, const py::array_t<double> thetav,
 }
 
 py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
-                                    const py::array_t<int> armav) {
+                                    const py::array_t<uint32_t> armav) {
   assert(xv.ndim() == 1);
   assert(armav.ndim() == 1);
 
@@ -540,9 +535,9 @@ py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
   const auto x = make_cspan(xv);
   const size_t n = x.size();
 
-  const int mp = arma[0];
-  const int mq = arma[1];
-  const int msp = arma[2];
+  const uint32_t mp = arma[0];
+  const uint32_t mq = arma[1];
+  const uint32_t msp = arma[2];
 
   std::array<double, 100> w1;
   std::array<double, 100> w2;
@@ -592,19 +587,16 @@ py::array_t<double> arima_gradtrans(const py::array_t<double> xv,
 }
 
 py::array_t<double> arima_undopars(const py::array_t<double> xv,
-                                   const py::array_t<int> armav) {
+                                   const py::array_t<uint32_t> armav) {
   assert(xv.ndim() == 1);
   assert(armav.ndim() == 1);
 
   const auto x = make_cspan(xv);
   const auto arma = make_cspan(armav);
 
-  const int mp = arma[0];
-  const int mq = arma[1];
-  const int msp = arma[2];
-  assert(mp >= 0);
-  assert(mq >= 0);
-  assert(msp >= 0);
+  const uint32_t mp = arma[0];
+  const uint32_t mq = arma[1];
+  const uint32_t msp = arma[2];
 
   py::array_t<double> outv(xv.size());
   const auto out = make_span(outv);
@@ -624,9 +616,8 @@ py::array_t<double> arima_undopars(const py::array_t<double> xv,
   return outv;
 }
 
-void invpartrans(const int p, const py::array_t<double> phiv,
+void invpartrans(const uint32_t p, const py::array_t<double> phiv,
                  py::array_t<double> outv) {
-  assert(p >= 0);
   assert(phiv.ndim() == 1);
   assert(outv.ndim() == 1);
   assert(p <= phiv.size());


### PR DESCRIPTION
Fixes https://github.com/Nixtla/statsforecast/issues/937. The code no longer segfaults in that scenario, but tries to allocate ~194 GB of memory and gets killed by oomkiller instead, would be probably nice to add an available memory check.

I had to bump cpp version to 20 in order to use `std::span`.

All i did was change types to size_t/uint32 where it made sense, added const where it was possible and I also added some `assert`s on preconditions.

I didn't find any tests, but i ran it before/after on the following configurations:
```python
ARIMA(order=(6, 1, 0))
ARIMA(order=(1, 1, 0), seasonal_order=(1, 0, 0), season_length=steps_day)
ARIMA(order=(1, 0, 0), seasonal_order=(1, 0, 0), season_length=steps_day)
ARIMA(order=(1, 0, 0), seasonal_order=(1, 1, 0), season_length=steps_day)
ARIMA(order=(0, 0, 0), seasonal_order=(1, 0, 0), season_length=steps_day)
ARIMA(order=(0, 0, 0), seasonal_order=(1, 1, 0), season_length=steps_day)
```
and got the exact same results.