### PR TITLE
fix: Mh update in _class3models

### DIFF
--- a/nbs/src/ets.ipynb
+++ b/nbs/src/ets.ipynb
@@ -1213,10 +1213,10 @@
     "        exp5 = np.matmul(sigma*G21, np.matmul(3*Vh+2*vecMh*vecMh.reshape(vecMh.shape[0],1), np.transpose(G21)))\n",
     "        Vh = exp1+sigma*(exp2+exp3+exp4+exp5) \n",
     "\n",
-    "    if trend == 'N': \n",
-    "        Mh = F1*np.matmul(Mh, np.transpose(F2))+G1*np.matmul(Mh, np.transpose(G2))*sigma\n",
-    "    else: \n",
-    "        Mh = np.matmul(F1, np.matmul(Mh, np.transpose(F2)))+np.matmul(G1,np.matmul(Mh, np.transpose(G2)))*sigma \n",
+    "        if trend == 'N':\n",
+    "            Mh = F1*np.matmul(Mh, np.transpose(F2))+G1*np.matmul(Mh, np.transpose(G2))*sigma\n",
+    "        else:\n",
+    "            Mh = np.matmul(F1, np.matmul(Mh, np.transpose(F2)))+np.matmul(G1,np.matmul(Mh, np.transpose(G2)))*sigma\n",
     "\n",
     "    return var"
    ]
@@ -1720,6 +1720,14 @@
     "            mape = np.abs(forecasts['mean'] / test_data - 1).mean()\n",
     "            assert mape < 0.3"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d8864ba60eb25438",
+   "metadata": {},
+   "outputs": [],
+   "source": ""
   }
  ],
  "metadata": {

--- a/python/statsforecast/ets.py
+++ b/python/statsforecast/ets.py
@@ -1032,16 +1032,16 @@ def _class3models(
         )
         Vh = exp1 + sigma * (exp2 + exp3 + exp4 + exp5)
 
-    if trend == "N":
-        Mh = (
-            F1 * np.matmul(Mh, np.transpose(F2))
-            + G1 * np.matmul(Mh, np.transpose(G2)) * sigma
-        )
-    else:
-        Mh = (
-            np.matmul(F1, np.matmul(Mh, np.transpose(F2)))
-            + np.matmul(G1, np.matmul(Mh, np.transpose(G2))) * sigma
-        )
+        if trend == "N":
+            Mh = (
+                F1 * np.matmul(Mh, np.transpose(F2))
+                + G1 * np.matmul(Mh, np.transpose(G2)) * sigma
+            )
+        else:
+            Mh = (
+                np.matmul(F1, np.matmul(Mh, np.transpose(F2)))
+                + np.matmul(G1, np.matmul(Mh, np.transpose(G2))) * sigma
+            )
 
     return var
 


### PR DESCRIPTION
`Mh` was outside the loop looping over `h`, therefore it didn't update and all variance terms were scaled by the first prediction.