### PR TITLE
ci: use arm runners for aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
         os-platform:
           [
             [ubuntu-latest, manylinux_x86_64],
-            [ubuntu-latest, manylinux_aarch64],
+            [ubuntu-24.04-arm, manylinux_aarch64],
             [windows-latest, win_amd64],
             [macos-13, macosx_x86_64],
             [macos-14, macosx_arm64],
@@ -37,12 +37,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "true"
-
-      - name: Set up QEMU
-        if: matrix.os-platform[1] == 'manylinux_aarch64'
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
-        with:
-          platforms: arm64
 
       - name: Set up uv
         uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
@@ -54,7 +48,6 @@ jobs:
         uses: pypa/cibuildwheel@ee63bf16da6cddfb925f542f2c7b59ad50e93969 # v2.22.0
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-${{ matrix.os-platform[1] }}
-          CIBW_TEST_SKIP: "*linux_aarch64"
           CIBW_BEFORE_TEST: yum install -y java
           CIBW_TEST_COMMAND: >
             uv pip install -r {project}/setup.py --extra all &&


### PR DESCRIPTION
Switches to the github hosted runners with arm64 for the aarch64 jobs to remove emulation.