### PR TITLE
fix(nelder-mead): argsort before early exit

### DIFF
--- a/nbs/src/ets.ipynb
+++ b/nbs/src/ets.ipynb
@@ -755,7 +755,7 @@
     "        1_000,\n",
     "        True,\n",
     "    )\n",
-    "    return results(*opt_res, None)"
+    "    return results(*opt_res)"
    ]
   },
   {

--- a/nbs/src/theta.ipynb
+++ b/nbs/src/theta.ipynb
@@ -479,7 +479,7 @@
     "        modeltype,\n",
     "        nmse\n",
     "    )\n",
-    "    return results(*opt_res, None)  # type: ignore"
+    "    return results(*opt_res)"
    ]
   },
   {

--- a/python/statsforecast/ets.py
+++ b/python/statsforecast/ets.py
@@ -501,7 +501,7 @@ def optimize_ets_target_fn(
         1_000,
         True,
     )
-    return results(*opt_res, None)
+    return results(*opt_res)
 
 # %% ../../nbs/src/ets.ipynb 26
 def etsmodel(

--- a/python/statsforecast/theta.py
+++ b/python/statsforecast/theta.py
@@ -127,7 +127,7 @@ def optimize_theta_target_fn(
         modeltype,
         nmse,
     )
-    return results(*opt_res, None)  # type: ignore
+    return results(*opt_res)
 
 # %% ../../nbs/src/theta.ipynb 14
 def thetamodel(

--- a/src/ets.cpp
+++ b/src/ets.cpp
@@ -279,15 +279,15 @@ double ObjectiveFunction(const VectorXd &params, const VectorXd &y, int n_state,
   }
   return obj_val;
 }
-std::tuple<VectorXd, double, int>
-Optimize(const Eigen::Ref<const VectorXd> &x0,
-         const Eigen::Ref<const VectorXd> &y, int n_state, Component error,
-         Component trend, Component season, Criterion opt_crit, int n_mse,
-         int m, bool opt_alpha, bool opt_beta, bool opt_gamma, bool opt_phi,
-         double alpha, double beta, double gamma, double phi,
-         const Eigen::Ref<const VectorXd> &lower,
-         const Eigen::Ref<const VectorXd> &upper, double tol_std, int max_iter,
-         bool adaptive) {
+nm::OptimResult Optimize(const Eigen::Ref<const VectorXd> &x0,
+                         const Eigen::Ref<const VectorXd> &y, int n_state,
+                         Component error, Component trend, Component season,
+                         Criterion opt_crit, int n_mse, int m, bool opt_alpha,
+                         bool opt_beta, bool opt_gamma, bool opt_phi,
+                         double alpha, double beta, double gamma, double phi,
+                         const Eigen::Ref<const VectorXd> &lower,
+                         const Eigen::Ref<const VectorXd> &upper,
+                         double tol_std, int max_iter, bool adaptive) {
   double init_step = 0.05;
   double nm_alpha = 1.0;
   double nm_gamma = 2.0;

--- a/src/theta.cpp
+++ b/src/theta.cpp
@@ -120,10 +120,10 @@ pegels_resid(const Eigen::Ref<const VectorXd> &y, ModelType model_type,
   return {amse, e, states, mse};
 }
 
-double theta_target_fn(const VectorXd &params, double init_level,
-                       double init_alpha, double init_theta, bool opt_level,
-                       bool opt_alpha, bool opt_theta, const VectorXd &y,
-                       ModelType model_type, size_t nmse) {
+double target_fn(const VectorXd &params, double init_level, double init_alpha,
+                 double init_theta, bool opt_level, bool opt_alpha,
+                 bool opt_theta, const VectorXd &y, ModelType model_type,
+                 size_t nmse) {
   RowMajorMatrixXd states = RowMajorMatrixXd::Zero(y.size(), 5);
   size_t j = 0;
   double level, alpha, theta;
@@ -152,13 +152,13 @@ double theta_target_fn(const VectorXd &params, double init_level,
   return mse;
 }
 
-std::tuple<VectorXd, double, int>
-optimize(const Eigen::Ref<const VectorXd> &x0,
-         const Eigen::Ref<const VectorXd> &lower,
-         const Eigen::Ref<const VectorXd> &upper, double init_level,
-         double init_alpha, double init_theta, bool opt_level, bool opt_alpha,
-         bool opt_theta, const Eigen::Ref<const VectorXd> &y,
-         ModelType model_type, size_t nmse) {
+nm::OptimResult optimize(const Eigen::Ref<const VectorXd> &x0,
+                         const Eigen::Ref<const VectorXd> &lower,
+                         const Eigen::Ref<const VectorXd> &upper,
+                         double init_level, double init_alpha,
+                         double init_theta, bool opt_level, bool opt_alpha,
+                         bool opt_theta, const Eigen::Ref<const VectorXd> &y,
+                         ModelType model_type, size_t nmse) {
   double init_step = 0.05;
   double zero_pert = 1e-4;
   double alpha = 1.0;
@@ -168,7 +168,7 @@ optimize(const Eigen::Ref<const VectorXd> &x0,
   int max_iter = 1'000;
   double tol_std = 1e-4;
   bool adaptive = true;
-  return nm::NelderMead(theta_target_fn, x0, lower, upper, init_step, zero_pert,
+  return nm::NelderMead(target_fn, x0, lower, upper, init_step, zero_pert,
                         alpha, gamma, rho, sigma, max_iter, tol_std, adaptive,
                         init_level, init_alpha, init_theta, opt_level,
                         opt_alpha, opt_theta, y, model_type, nmse);


### PR DESCRIPTION
Ensures that the `best_idx` in nelder mead is correct when exiting early.