### PR TITLE
Add `uses_exog = True` to AutoMFLES

### DIFF
--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -1367,6 +1367,8 @@ class AutoMFLES(_TS):
         Custom name of the model.
     """
 
+    uses_exog = True
+
     def __init__(
         self,
         test_size: int,


### PR DESCRIPTION
## Summary

The AutoMFLES implementation was missing the `uses_exog = True` flag. As far as I'm aware it should accept exogenous data (as in the simple MFLES model).

- added `uses_exog = True` to `AutoMFLES`

Let me know if you need additional info :)


