### PR TITLE
Fixes broken links

### DIFF
--- a/experiments/ces/README.md
+++ b/experiments/ces/README.md
@@ -26,7 +26,7 @@ Additionally, with StatsForecast you can easly build ensembles of all statstical
 
 ## References
 
-* Check the StatsForecast [documentation](https://nixtla.github.io/statsforecast/models.html#autoces) on the CES
+* Check the StatsForecast [documentation](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoCES) on the CES
 * [Link](https://forecasting.svetunkov.ru/wp-content/uploads/2022/07/Svetunkov-et-al.-2022-Complex-Exponential-Smoothing.pdf) to the original paper
 * [Link](https://forecasting.svetunkov.ru/en/2022/08/02/the-long-and-winding-road-the-story-of-complex-exponential-smoothing/) to the story of the paper
 

--- a/experiments/ets_intervals/README.md
+++ b/experiments/ets_intervals/README.md
@@ -2,20 +2,20 @@
 
 ## Introduction 
 
-[AutoETS](https://nixtla.github.io/statsforecast/models.html#autoets) is a fast and reliable model in [StatsForecast](https://nixtla.github.io/statsforecast/) that automatically selects the best [ETS model](https://otexts.com/fpp3/ets.html) for a given time series. It is a probabilistic model and it can generate prediction intervals for any confidence level. In this experiment, we'll show that these prediction intervals are accurate and fast when compared to two well-known forecasting libraries: R's [forecast](https://pkg.robjhyndman.com/forecast/) package and [statsmodels](https://www.statsmodels.org/dev/index.html). 
+[AutoETS](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoETS) is a fast and reliable model in [StatsForecast](https://nixtlaverse.nixtla.io/statsforecast/) that automatically selects the best [ETS model](https://otexts.com/fpp3/ets.html) for a given time series. It is a probabilistic model and it can generate prediction intervals for any confidence level. In this experiment, we'll show that these prediction intervals are accurate and fast when compared to two well-known forecasting libraries: R's [forecast](https://pkg.robjhyndman.com/forecast/) package and [statsmodels](https://www.statsmodels.org/dev/index.html). 
 
 ## Experiment 
 
 We'll use the [M4 Competition](https://www.sciencedirect.com/science/article/pii/S0169207019301128) dataset, which consists of 100,000 time series of different frequencies. Each frequency has a different forecast horizon. 
 
-| dataset  |Number of series | Forecast horizon| 
-|:---------|:---------------:|:---------------:|
-| Hourly   | 414             | 48              |
-| Daily    | 4227            | 14              |
-| Weekly   | 359             | 13              |
-| Monthly  | 48000           | 18              |
-| Quarterly| 24000           | 8               |
-| Yearly   | 23000           | 6               |
+| dataset   | Number of series | Forecast horizon |
+| :-------- | :--------------: | :--------------: |
+| Hourly    |       414        |        48        |
+| Daily     |       4227       |        14        |
+| Weekly    |       359        |        13        |
+| Monthly   |      48000       |        18        |
+| Quarterly |      24000       |        8         |
+| Yearly    |      23000       |        6         |
 
 Our goal is to generate prediction intervals for all time series with the following confidence levels: 55, 60, 65, 70, 75, 80, 85, 90, and 95%.
 
@@ -30,26 +30,26 @@ Both StatsForecast and R can automatically select the best ETS model for a given
 
 ## Results 
 
-| dataset   | metric                      |   ets_r |   ets_statsforecast |   ets_statsmodels |
-|:----------|:----------------------------|--------:|--------------------:|------------------:|
-| Daily     | Winkler-score (with mean)   | 1754    |             1580.63 |   69321.7         |
-| Daily     | Winkler-score (with median) |  632.69 |              636.48 |     695.96        |
-| Daily     | time                        |  114.08 |              211.63 |     145.82        |
-| Hourly    | Winkler-score (with mean)   | 4616.11 |             5893.55 |       5.40095e+12 |
-| Hourly    | Winkler-score (with median) |  231.3  |              344.47 |     238.61        |
-| Hourly    | time                        |  219.4  |              159.67 |     761.04        |
-| Monthly   | Winkler-score (with mean)   | 4063.74 |             3993.32 |       5.0763e+16  |
-| Monthly   | Winkler-score (with median) | 1773.16 |             1739.38 |    1840.05        |
-| Monthly   | time                        | 8320.72 |             3708.56 |   18464.3         |
-| Quarterly | Winkler-score (with mean)   | 3718.22 |             3683.87 |       1.45623e+20 |
-| Quarterly | Winkler-score (with median) | 1732.94 |             1712.99 |    1788.29        |
-| Quarterly | time                        |  706.95 |              601.32 |    2549.96        |
-| Weekly    | Winkler-score (with mean)   | 2112.91 |             2104.58 |    2917.29        |
-| Weekly    | Winkler-score (with median) | 1165.56 |             1157.86 |    1410.7         |
-| Weekly    | time                        |    4.18 |               25.55 |       8.53        |
-| Yearly    | Winkler-score (with mean)   | 6073.66 |             5519.2  |       1.23671e+07 |
-| Yearly    | Winkler-score (with median) | 2762.89 |             2529.52 |    2914.6         |
-| Yearly    | time                        |  315.47 |               58.19 |     395.92        |
+| dataset   | metric                      |   ets_r | ets_statsforecast | ets_statsmodels |
+| :-------- | :-------------------------- | ------: | ----------------: | --------------: |
+| Daily     | Winkler-score (with mean)   |    1754 |           1580.63 |         69321.7 |
+| Daily     | Winkler-score (with median) |  632.69 |            636.48 |          695.96 |
+| Daily     | time                        |  114.08 |            211.63 |          145.82 |
+| Hourly    | Winkler-score (with mean)   | 4616.11 |           5893.55 |     5.40095e+12 |
+| Hourly    | Winkler-score (with median) |   231.3 |            344.47 |          238.61 |
+| Hourly    | time                        |   219.4 |            159.67 |          761.04 |
+| Monthly   | Winkler-score (with mean)   | 4063.74 |           3993.32 |      5.0763e+16 |
+| Monthly   | Winkler-score (with median) | 1773.16 |           1739.38 |         1840.05 |
+| Monthly   | time                        | 8320.72 |           3708.56 |         18464.3 |
+| Quarterly | Winkler-score (with mean)   | 3718.22 |           3683.87 |     1.45623e+20 |
+| Quarterly | Winkler-score (with median) | 1732.94 |           1712.99 |         1788.29 |
+| Quarterly | time                        |  706.95 |            601.32 |         2549.96 |
+| Weekly    | Winkler-score (with mean)   | 2112.91 |           2104.58 |         2917.29 |
+| Weekly    | Winkler-score (with median) | 1165.56 |           1157.86 |          1410.7 |
+| Weekly    | time                        |    4.18 |             25.55 |            8.53 |
+| Yearly    | Winkler-score (with mean)   | 6073.66 |            5519.2 |     1.23671e+07 |
+| Yearly    | Winkler-score (with median) | 2762.89 |           2529.52 |          2914.6 |
+| Yearly    | time                        |  315.47 |             58.19 |          395.92 |
 
 *Note*: Time is measured in seconds
 
@@ -68,9 +68,9 @@ Both StatsForecast and R can automatically select the best ETS model for a given
 - StatsForecast's AutoETS produces prediction intervals that are close in accuracy to the ones produced by R's forecast library and by statsmodels. 
 - For most frequencies, StatsForecast is faster than R and statsmodels. In the monthly frequency, which corresponds to 48% of the M4 Competition dataset, StatsForecast is 2.2x faster than R and 5x faster than statsmodels. 
 - In terms of accuracy, StatsForecast's results are not surprising since AutoETS is a mirror of R's ets function. However, in terms of time, StatsForecast's performance is superior to both R and statsmodels. 
-- StatsForecast has multiple probabilistic models in addition to AutoETS. See the full list [here.](https://nixtla.github.io/statsforecast/examples/models_intro.html). 
+- StatsForecast has multiple probabilistic models in addition to AutoETS. See the full list [here.](https://nixtlaverse.nixtla.io/statsforecast/src/core/models_intro). 
 
 ## References 
 
-- StatsForecast [quick start guide.](https://nixtla.github.io/statsforecast/examples/getting_started_short.html) 
+- StatsForecast [quick start guide.](https://nixtlaverse.nixtla.io/statsforecast/docs/getting-started/1_Getting_Started_short) 
 - A tutorial on probabilistic forecasting using StatsForecast can be found [here.](https://nixtla.github.io/statsforecast/examples/uncertaintyintervals.html)

--- a/experiments/m3/README.md
+++ b/experiments/m3/README.md
@@ -32,7 +32,7 @@ Building upon the original design, we further included [A simple combination of 
 
 This ensemble is formed by averaging four statistical models: [`AutoARIMA`](https://www.jstatsoft.org/article/view/v027i03), [`ETS`](https://robjhyndman.com/expsmooth/), [`CES`](https://onlinelibrary.wiley.com/doi/full/10.1002/nav.22074) and [`DynamicOptimizedTheta`](https://doi.org/10.1016/j.ijforecast.2016.02.005). This combination won sixth place and was the simplest ensemble among the top 10 performers in the M4 competition. 
  
-For the experiment, we use StatsForecast's implementation of [Arima](https://nixtla.github.io/statsforecast/models.html#autoarima), [ETS](https://nixtla.github.io/statsforecast/models.html#autoets), [CES](https://nixtla.github.io/statsforecast/models.html#autoces) and [DOT](https://nixtla.github.io/statsforecast/models.html#dynamic-optimized-theta-method). 
+For the experiment, we use StatsForecast's implementation of [Arima](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoARIMA), [ETS](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoETS), [CES](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoCES) and [DOT](https://nixtlaverse.nixtla.io/statsforecast/docs/models/DynamicOptimizedTheta). 
 
 For the DL models and ensembles, we reproduce the reported metrics and results from the mentioned paper.
 
@@ -56,9 +56,9 @@ Computational complexity is reported in time, lines of code and, Relative Comput
 #### Time
 Using `StatsForecast` and a 96 cores EC2 instance (c5d.24xlarge) it takes 5.6 mins to train, forecast and ensemble the four models for the 3,003 series of M3. 
 
-| Time (mins) | Yearly | Quarterly | Monthly | Other |
-|-----|-------:|-------:|--------:|--------:|
-|StatsForecast ensemble| 1.10 | 1.32 | 2.38 | 1.08 |
+| Time (mins)            | Yearly | Quarterly | Monthly | Other |
+| ---------------------- | -----: | --------: | ------: | ----: |
+| StatsForecast ensemble |   1.10 |      1.32 |    2.38 |  1.08 |
 
 The authors of the paper only report computational time for the monthly group, which amounts to 20,680 mins or 14.3 days. In comparison, the StatsForecast ensemble only takes 2.38 minutes to run for that group. Furthermore, the authors don't include times for Hyperparameter optimization. 
 
@@ -75,15 +75,15 @@ Using a `c5d.24xlarge` instance (96 CPU, 192 GB RAM) it takes 12 seconds to trai
 
 In the next table, you can find the RCC of the deep learning models and the ensembles
 
-| Method | Type | Relative Computational Complexity (RCC)|
-|--------|------|----------------------------------------:|
-|DeepAR| DL |313,000|
-|Feed-Forward| DL  |47,300 |
-|Transformer| DL | 47,500 |
-|WaveNet| DL | 306,000 |
-|Ensemble-DL | DL | 713,800 |
-|Ensemble - Stats | Statistical | 28 |
-|SeasonalNaive| Benchmark | 1 | 
+| Method           | Type        | Relative Computational Complexity (RCC) |
+| ---------------- | ----------- | --------------------------------------: |
+| DeepAR           | DL          |                                 313,000 |
+| Feed-Forward     | DL          |                                  47,300 |
+| Transformer      | DL          |                                  47,500 |
+| WaveNet          | DL          |                                 306,000 |
+| Ensemble-DL      | DL          |                                 713,800 |
+| Ensemble - Stats | Statistical |                                      28 |
+| SeasonalNaive    | Benchmark   |                                       1 |
 
 
 ### Summary: Comparison with SOTA benchmarks

--- a/experiments/mstl/README.md
+++ b/experiments/mstl/README.md
@@ -51,7 +51,7 @@ The `SeasonalNaive` model is a simple baseline model that sets each forecast to 
 The `MSTL` (Multiple Seasonal-Trend decomposition using LOESS) model, originally developed by [Kasun Bandara, Rob J Hyndman and Christoph Bergmeir](https://arxiv.org/abs/2107.13462), decomposes the time series in multiple seasonalities using a Local Polynomial Regression (LOESS). Then it forecasts the trend using a custom non-seasonal model and each seasonality using a `SeasonalNaive` model.
 
 `StatsForecast` contains a fast implementation of the `MSTL` model.
-[Documentation](https://nixtla.github.io/statsforecast/examples/multipleseasonalities.html)
+[Documentation](https://nixtlaverse.nixtla.io/statsforecast/docs/tutorials/MultipleSeasonalities)
 
 
 ### Performance Evaluation
@@ -85,12 +85,12 @@ The performance of the models was evaluated re-training the models every 24 hour
 
 ### Time
 
-| Model | Time (mins) |
-| -------| -----------|
-| SN | 0.03 |                                  
-| MSTL   |  1.066439|                                    
-|Prophet  |2.343852|                            
-|  NeuralProphet  |9.643826 |
+| Model         | Time (mins) |
+| ------------- | ----------- |
+| SN            | 0.03        |
+| MSTL          | 1.066439    |
+| Prophet       | 2.343852    |
+| NeuralProphet | 9.643826    |
 
 ## Conclusion
 

--- a/nbs/blog/posts/2022-10-05-distributed-fugue/index.qmd
+++ b/nbs/blog/posts/2022-10-05-distributed-fugue/index.qmd
@@ -146,7 +146,7 @@ On the scale of one million timeseries, our total training time took 12 minutes 
 
 ## Resources
 1. [Nixtla StatsForecast repo](https://github.com/Nixtla/statsforecast)
-2. [StatsForecast docs](https://nixtla.github.io/statsforecast/)
+2. [StatsForecast docs](https://nixtlaverse.nixtla.io/statsforecast/)
 3. [Fugue repo](https://github.com/fugue-project/fugue/)
 4. [Fugue tutorials](https://fugue-tutorials.readthedocs.io/)
 

--- a/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
+++ b/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
@@ -600,7 +600,7 @@
    "source": [
     "StatsForecast and MSTL in particular are good benchmarking models for peak detection. However, it might be useful to explore further and newer forecasting algorithms. We have seen particularly good results with the N-HiTS, a deep-learning model from Nixtla's NeuralForecast library.\n",
     "\n",
-    "Learn how to predict ERCOT demand peaks with our deep-learning N-HiTS model and the NeuralForecast library in [this tutorial](https://nixtla.github.io/neuralforecast/examples/electricitypeakforecasting.html)."
+    "Learn how to predict ERCOT demand peaks with our deep-learning N-HiTS model and the NeuralForecast library in [this tutorial](https://nixtlaverse.nixtla.io/neuralforecast/docs/use-cases/electricity_peak_forecasting)."
    ]
   },
   {

--- a/nbs/docs/tutorials/IntermittentData.ipynb
+++ b/nbs/docs/tutorials/IntermittentData.ipynb
@@ -316,7 +316,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The models for intermittent series that are currently available in StatsForecast can only generate point-forecasts. If prediction intervals are needed, then a [probabilisitic model](https://nixtla.github.io/statsforecast/#models) should be used. "
+    "The models for intermittent series that are currently available in StatsForecast can only generate point-forecasts. If prediction intervals are needed, then a [probabilisitic model](https://nixtlaverse.nixtla.io/statsforecast/models) should be used. "
    ]
   },
   {


### PR DESCRIPTION
Fixes the broken links inside:

- StatisticalNeuralMethods
- ElectricityPeakForecasting
- IntermittentData
- blog/distributed-fugue
- experiments/ces
- experiments/m3
- experiments/mstl

Still contain broken links:

- experiments/ets_intervals/README.md
- experiments/amazon_forecast/README.md

The reason I didn't fixed them its because it leads to the uncertaintyintervals and experiments/aws which aren't defined in the new docs.