### PR TITLE
remove extra double quote in link

### DIFF
--- a/nbs/docs/models/AutoARIMA.ipynb
+++ b/nbs/docs/models/AutoARIMA.ipynb
@@ -127,7 +127,7 @@
                 "\n",
                 "Selecting appropriate values for p, d and q can be difficult. However, the `AutoARIMA()` function from `statsforecast` will do it for you automatically.\n",
                 "\n",
-                "For more information [here](\"https://otexts.com/fpp3/non-seasonal-arima.html\")\n"
+                "For more information [here](https://otexts.com/fpp3/non-seasonal-arima.html)\n"
             ]
         },
         {


### PR DESCRIPTION
Double quotes around link was making it being rendered to `%22https://otexts.com/fpp3/non-seasonal-arima.html%22` instead of just `https://otexts.com/fpp3/non-seasonal-arima.html` thus making the link be broken

<img width="718" height="48" alt="Screenshot 2025-11-20 at 3 28 47 PM" src="https://github.com/user-attachments/assets/07975f58-92f1-4762-826e-024fcbf81c76" />
