### PR TITLE
fix: raise ValueError for h>1 in forecast_fitted_values

### DIFF
--- a/python/statsforecast/core.py
+++ b/python/statsforecast/core.py
@@ -871,19 +871,31 @@ class _StatsForecast:
         self.forecast_times_ = res_fcsts["times"]
         return fcsts_df
 
-    def forecast_fitted_values(self):
+    def forecast_fitted_values(self, h: int = 1):
         """Retrieve in-sample predictions from the forecast method.
 
         Returns the fitted (in-sample) predictions generated during the last call to
         `forecast()`. These are the model's predictions on the training data, useful
         for assessing model fit quality and identifying patterns in residuals.
 
+        Args:
+            h (int, optional): Forecast horizon. Currently only h=1 is supported.
+                Multi-step in-sample forecasts are not available through this method.
+
         Returns:
             pandas.DataFrame or polars.DataFrame: DataFrame containing in-sample predictions
                 with columns for series identifiers, timestamps, target values, and fitted
                 predictions from each model. Includes prediction intervals if they were
                 requested during forecasting.
+
+        Raises:
+            ValueError: If h > 1, as multi-step in-sample forecasts are not supported.
         """
+        if h > 1:
+            raise ValueError(
+                "forecast_fitted_values currently supports only h=1. "
+                "Use cross_validation or forecast() for multi-step predictions."
+            )
         if not hasattr(self, "fcst_fitted_values_"):
             raise Exception("Please run `forecast` method using `fitted=True`")
         cols = self.fcst_fitted_values_["cols"]
@@ -1592,11 +1604,11 @@ class StatsForecast(_StatsForecast):
             target_col=target_col,
         )
 
-    def forecast_fitted_values(self):
+    def forecast_fitted_values(self, h: int = 1):
         if hasattr(self, "_backend"):
-            res = self._backend.forecast_fitted_values()
+            res = self._backend.forecast_fitted_values(h=h)
         else:
-            res = super().forecast_fitted_values()
+            res = super().forecast_fitted_values(h=h)
         return res
 
     def cross_validation(

--- a/tests/test_issue_1032.py
+++ b/tests/test_issue_1032.py
@@ -1,0 +1,69 @@
+"""Tests for Issue #1032: forecast_fitted_values() h>1 validation."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from statsforecast.core import StatsForecast
+from statsforecast.models import Naive
+
+
+@pytest.fixture
+def simple_series():
+    """Create a simple time series for testing."""
+    return pd.DataFrame(
+        {
+            "unique_id": ["series_1"] * 20,
+            "ds": pd.date_range("2020-01-01", periods=20, freq="D"),
+            "y": np.arange(1, 21, dtype=float),
+        }
+    )
+
+
+class TestForecastFittedValuesHorizon:
+    """Test forecast_fitted_values h parameter validation."""
+
+    def test_forecast_fitted_values_h1_works(self, simple_series):
+        """Test that h=1 (default) works correctly."""
+        sf = StatsForecast(models=[Naive()], freq="D")
+        sf.forecast(df=simple_series, h=5, fitted=True)
+
+        # h=1 should work (default)
+        fitted = sf.forecast_fitted_values()
+        assert fitted is not None
+        assert len(fitted) == len(simple_series)
+
+        # Explicit h=1 should also work
+        fitted_explicit = sf.forecast_fitted_values(h=1)
+        pd.testing.assert_frame_equal(fitted, fitted_explicit)
+
+    def test_forecast_fitted_values_h_greater_than_1_raises(self, simple_series):
+        """Test that h>1 raises ValueError with helpful message."""
+        sf = StatsForecast(models=[Naive()], freq="D")
+        sf.forecast(df=simple_series, h=5, fitted=True)
+
+        # h=2 should raise ValueError
+        with pytest.raises(ValueError) as exc_info:
+            sf.forecast_fitted_values(h=2)
+
+        error_msg = str(exc_info.value)
+        assert "h=1" in error_msg
+        assert "cross_validation" in error_msg or "forecast()" in error_msg
+
+    def test_forecast_fitted_values_h5_raises(self, simple_series):
+        """Test that h=5 also raises ValueError."""
+        sf = StatsForecast(models=[Naive()], freq="D")
+        sf.forecast(df=simple_series, h=5, fitted=True)
+
+        with pytest.raises(ValueError):
+            sf.forecast_fitted_values(h=5)
+
+    def test_forecast_fitted_values_without_fitted_raises(self, simple_series):
+        """Test that calling without fitted=True still raises appropriate error."""
+        sf = StatsForecast(models=[Naive()], freq="D")
+        sf.forecast(df=simple_series, h=5, fitted=False)
+
+        with pytest.raises(Exception) as exc_info:
+            sf.forecast_fitted_values()
+
+        assert "fitted=True" in str(exc_info.value)


### PR DESCRIPTION
Fixes #1032

### Description
This PR addresses the issue where [forecast_fitted_values](cci:1://file:///c:/Users/GAURAV%20PATIL/Desktop/gaurav%27s%20code/Open-Source/statsforecast/python/statsforecast/core.py:1606:4-1611:18) silently ignores multi-step expectations or behaves ambiguously when users try to generate in-sample forecasts for `h > 1`. 

Forecast fitted values are conceptually 1-step-ahead predictions. To prevent user confusion and incorrect usage, this change makes the restriction explicit.

### Changes
- **Core Logic**: Updated `_StatsForecast.forecast_fitted_values` and `StatsForecast.forecast_fitted_values` to accept an `h` parameter (defaulting to `1`).
- **Validation**: Added a check to explicitly raise a `ValueError` if `h > 1`. The error message guides new users to use [cross_validation](cci:1://file:///c:/Users/GAURAV%20PATIL/Desktop/gaurav%27s%20code/Open-Source/statsforecast/python/statsforecast/core.py:1613:4-1707:9) or [forecast()](cci:1://file:///c:/Users/GAURAV%20PATIL/Desktop/gaurav%27s%20code/Open-Source/statsforecast/python/statsforecast/models.py:1626:4-1685:18) for multi-step predictions.
- **Tests**: Added regression tests ([tests/test_issue_1032.py](cci:7://file:///c:/Users/GAURAV%20PATIL/Desktop/gaurav%27s%20code/Open-Source/statsforecast/tests/test_issue_1032.py:0:0-0:0)) to verify:
    - `h=1` works as expected (default logic preserved).
    - `h>1` correctly raises `ValueError`.

### Checklist
- [x] Code passes all tests
- [x] New tests added
- [x] Docstrings updated to reflect the new `h` parameter and `ValueError`