### PR TITLE
[FIX] UCM.new(): clear model_ on the clone to avoid sharing fitted state

### DIFF
--- a/python/statsforecast/ucm.py
+++ b/python/statsforecast/ucm.py
@@ -178,6 +178,7 @@ class UCM:
         """Create a copy of the model."""
         b = type(self).__new__(type(self))
         b.__dict__.update(self.__dict__)
+        b.model_ = None
         return b
 
     def _build_model(self, y: np.ndarray, X: Optional[np.ndarray] = None):


### PR DESCRIPTION
`UCM.new()` does `b.__dict__.update(self.__dict__)`, so the returned clone holds the same `model_` dict (and the same underlying statsmodels `results` object) as the original. Cross-validation pipelines that obtain an unfitted twin via `.new()` end up sharing fitted state across instances.

### Reproducer

```python
import numpy as np
from statsforecast.models import UCM

y = np.cumsum(np.random.default_rng(0).standard_normal(80)) + 100
m = UCM(level="local level"); m.fit(y)

clone = m.new()
assert clone.model_ is m.model_                          # currently True
assert clone.model_["results"] is m.model_["results"]    # currently True
```

### Fix

```diff
 def new(self):
     b = type(self).__new__(type(self))
     b.__dict__.update(self.__dict__)
+    b.model_ = None
     return b
```

This matches the pattern in other model classes that use `new()` to obtain an unfitted twin.