### PR TITLE
[CHORE] ci.yaml: scope publish-nightly-wheels AWS env to the publish step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,9 +83,6 @@ jobs:
   publish-nightly-wheels:
     if: github.event_name == 'push'
     needs: [run-tests]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_NIXTLA_PACKAGES }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_NIXTLA_PACKAGES }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -102,6 +99,9 @@ jobs:
           python-version: "3.10"
 
       - name: Publish wheels
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_NIXTLA_PACKAGES }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_NIXTLA_PACKAGES }}
         run: |
           pip install awscli beautifulsoup4
           aws s3 cp s3://nixtla-packages/statsforecast/index.html .


### PR DESCRIPTION
The `publish-nightly-wheels` job in `ci.yaml` declares the AWS credentials at the **job** level (lines 86–89), so the keys are present in the env of every step — `actions/checkout`, `actions/download-artifact`, `actions/setup-python`, `pip install awscli beautifulsoup4` — even though only the final `Publish wheels` step calls `aws s3`.

Moving the env block to the single step that needs it follows the same least-privilege intent as #1112 (explicit workflow `permissions:`) and matches how the OIDC token is already step-scoped in `python-publish.yml`.

### Diff

```diff
 publish-nightly-wheels:
     if: github.event_name == 'push'
     needs: [run-tests]
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_NIXTLA_PACKAGES }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_NIXTLA_PACKAGES }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@…
       …
       - name: Publish wheels
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_NIXTLA_PACKAGES }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_NIXTLA_PACKAGES }}
         run: |
           pip install awscli beautifulsoup4
           ...
```