### PR TITLE
[FIX] reject confidence levels outside (0, 100)

### DIFF
--- a/python/statsforecast/core.py
+++ b/python/statsforecast/core.py
@@ -715,6 +715,11 @@ class _StatsForecast:
     ):
         if level is None:
             level = []
+        # Reject impossible confidence levels at the entry point so the
+        # error surfaces with a clear message instead of silently producing
+        # `lo--5` / `hi--5` columns whose lo > hi (see #482).
+        from statsforecast.utils import _check_level
+        _check_level(level)
         if X is None:
             return X, level
         expected_shape = (h * len(self.ga), self.ga.data.shape[1] + 1)

--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -194,6 +194,10 @@ class _TS:
 
     def _add_conformal_intervals(self, fcst, y, X, level):
         if self.prediction_intervals is not None and level is not None:
+            # Validate before computing scores — bad levels would otherwise
+            # silently produce swapped lo/hi columns. See #482.
+            from statsforecast.utils import _check_level
+            _check_level(level)
             cs = self._conformity_scores(y, X) if y is not None else self._cs
             res = self._conformal_method(fcst=fcst, cs=cs, level=level)
             return res

--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -267,6 +267,28 @@ def _naive(
 
 
 # Functions used for calculating prediction intervals
+def _check_level(level):
+    """Validate a confidence-level argument.
+
+    Each entry must be a real number in the open interval (0, 100). Negative
+    values are silently accepted by the rest of the pipeline (#482) and yield
+    swapped lo/hi columns whose names also contain a stray ``--`` (e.g.
+    ``lo--5``), so we reject them at the boundary instead.
+    """
+    if level is None:
+        return
+    arr = np.asarray(level, dtype=float).ravel()
+    if arr.size == 0:
+        return
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"`level` must be finite, got {list(level)}")
+    if (arr <= 0).any() or (arr >= 100).any():
+        raise ValueError(
+            "`level` values must lie strictly between 0 and 100; "
+            f"got {list(level)}"
+        )
+
+
 def _quantiles(level):
     level = np.asarray(level)
     z = norm.ppf(0.5 + level / 200)
@@ -274,6 +296,7 @@ def _quantiles(level):
 
 
 def _calculate_intervals(out, level, h, sigmah):
+    _check_level(level)
     z = _quantiles(np.asarray(level))
     zz = np.repeat(z, h)
     zz = zz.reshape(z.shape[0], h)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2114,3 +2114,37 @@ class TestNaNModel:
     def test_alias_arg(self):
         assert repr(NaNModel()) == "NaNModel"
         assert repr(NaNModel(alias="NaN_custom")) == "NaN_custom"
+
+
+class TestLevelValidation:
+    """Regression for #482 — confidence levels outside (0, 100) used to be
+    silently accepted and produced ``lo--5`` columns whose ``lo > hi``. Each
+    case here failed on origin/main: ``predict`` returned a result instead of
+    raising.
+    """
+
+    @pytest.mark.parametrize("bad", [[-5], [-5, 5], [0], [100], [101], [200]])
+    def test_naive_predict_rejects_bad_levels(self, bad):
+        from statsforecast.models import Naive
+
+        model = Naive()
+        model.fit(y=ap)
+        with pytest.raises(ValueError, match="level"):
+            model.predict(h=4, level=bad)
+
+    @pytest.mark.parametrize("bad", [[-1, 95], [50, -1]])
+    def test_naive_forecast_rejects_bad_levels(self, bad):
+        from statsforecast.models import Naive
+
+        with pytest.raises(ValueError, match="level"):
+            Naive().forecast(y=ap, h=4, level=bad)
+
+    def test_valid_levels_still_work(self):
+        """Sanity check: valid levels still produce well-ordered intervals."""
+        from statsforecast.models import Naive
+
+        out = Naive().forecast(y=ap, h=4, level=[80, 95])
+        for lv in (80, 95):
+            # Every predicted lo must be <= the matching hi — this would be
+            # silently violated for negative levels on origin/main.
+            assert (out[f"lo-{lv}"] <= out[f"hi-{lv}"]).all()


### PR DESCRIPTION
## Summary

Negative or out-of-range confidence levels were silently accepted by the prediction-interval pipeline. Add a single ``_check_level`` validator at the three funnel points so the offending input raises a clear ``ValueError`` instead of producing columns whose ``lo > hi``.

Fixes Nixtla/statsforecast#482 — *negative values in confidence levels for prediction intervals should not be allowed*

## Context

Each model's `predict`/`forecast` accepts a `level` argument that the docs describe as the confidence level percentage. There was no validation, so e.g. ``Naive().predict(h=4, level=[-5, 5])`` happily returned a dict with keys ``lo--5``, ``hi--5``, ``lo-5``, ``hi-5`` — note the stray ``--`` from the `f"lo-{lv}"` formatting — and the values for the ``-5`` pair had ``lo > hi`` (because ``-5`` flips the sign on the `z`-score). The user reported this in 2023.

The validation was added at the three funnel points instead of every model's `predict`/`forecast`:

- ``utils._calculate_intervals`` — the analytical PI path used by every classical model.
- ``models._TS._add_conformal_intervals`` — the conformal PI path used when ``prediction_intervals`` is configured.
- ``core.StatsForecast._parse_X_level`` — the top-level entry for ``StatsForecast.predict/forecast/cross_validation``.

## Changes

- ``python/statsforecast/utils.py`` — new ``_check_level`` helper. Raises ``ValueError`` for any non-finite entry or any entry outside the open interval ``(0, 100)``. The docstring carries an inline reference to #482 so a future reader knows which contract this guard preserves.
- ``python/statsforecast/models.py`` — call the helper inside ``_TS._add_conformal_intervals`` so conformal users see the error too.
- ``python/statsforecast/core.py`` — call the helper inside ``_parse_X_level`` so ``StatsForecast`` users see the error at the boundary.
- ``tests/test_models.py`` — new ``TestLevelValidation`` class with parametrised regression coverage (negative, zero, 100, > 100, mixed-good-and-bad), plus a positive control that verifies valid levels still produce well-ordered intervals.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/Nixtla/statsforecast.git /tmp/sf-482 && cd /tmp/sf-482
git submodule update --init --recursive
python -m venv .venv && source .venv/bin/activate
pip install --no-build-isolation -e . pytest

REPRO='
from statsforecast.utils import AirPassengers as ap
from statsforecast.models import Naive
m = Naive()
m.fit(y=ap)
out = m.predict(h=4, level=[-5, 5])
# Show the silently-broken contract: lo > hi for the -5 column
import numpy as np
assert (out["lo--5"] <= out["hi--5"]).all(), (
    f"lo > hi for negative level: lo={out[chr(34)+chr(108)+chr(111)+chr(45)+chr(45)+chr(53)+chr(34)]}, hi={out[chr(34)+chr(104)+chr(105)+chr(45)+chr(45)+chr(53)+chr(34)]}"
)
print("OK")
'

# --- BEFORE (origin/main) ---
git checkout origin/main
python -c "$REPRO"
# Expected: AssertionError "lo > hi for negative level" (or no error and a printed OK if the user does not assert) — i.e. the broken values come back without any complaint from the library.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/statsforecast.git feat/482-validate-level
git checkout FETCH_HEAD
python -c "$REPRO"
# Expected: ValueError: \`level\` values must lie strictly between 0 and 100; got [-5, 5]
```

## What I ran locally

- ``pytest tests/test_models.py -q --no-cov`` → **211/211 passed** (was 202; 9 added by ``TestLevelValidation``).
- ``pytest tests/test_theta.py tests/test_ets.py tests/test_arima.py tests/test_core.py -q --no-cov`` → **135 passed** in ``test_core``, ``test_theta`` 23 passed, ``test_ets``/``test_arima`` all green.
- Stashing the source change makes every parametrised case in ``TestLevelValidation::test_naive_predict_rejects_bad_levels`` fail on origin/main (predict returned a result instead of raising), confirming the test exercises the bug.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Single negative entry (the report) | ``level=[-5]`` | ``ValueError`` | ``test_naive_predict_rejects_bad_levels[bad0]`` |
| 2 | Mixed valid + negative | ``level=[-5, 5]`` (the original report) | ``ValueError`` | ``test_naive_predict_rejects_bad_levels[bad1]`` |
| 3 | Boundary ``0`` and ``100`` | ``level=[0]``, ``level=[100]`` | ``ValueError`` (level is *strictly* (0, 100)) | ``test_naive_predict_rejects_bad_levels[bad2,bad3]`` |
| 4 | Out-of-range high | ``level=[101]``, ``level=[200]`` | ``ValueError`` | ``test_naive_predict_rejects_bad_levels[bad4,bad5]`` |
| 5 | Valid levels (positive control) | ``level=[80, 95]`` | well-ordered ``lo <= hi`` for each level | ``test_valid_levels_still_work`` |
| 6 | Conformal path | ``ConformalIntervals`` configured + bad level | ``ValueError`` from ``_add_conformal_intervals`` | covered indirectly: same helper, same exception path |

## Risk / blast radius

Additive validation — any caller passing a level that is currently producing nonsense will now see a clean error instead. Callers using only valid levels are unaffected (verified by the unchanged ``test_models.py`` suite of 202 pre-existing tests).

## Release note

```release-note
fix(core): raise ValueError when `level` contains entries outside the open interval (0, 100). Previously such inputs silently produced prediction-interval columns whose lower bound exceeded the upper bound.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against the three funnel points used by analytical, conformal, and StatsForecast PI paths. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*