### PR TITLE
[FIX] SeasonalNaive: align short-history forecasts with the seasonal period

### DIFF
--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -236,8 +236,18 @@ def _seasonal_naive(
     y = _ensure_float(y)
     n = y.size
     season_vals = np.full(season_length, np.nan, dtype=y.dtype)
-    season_samples = min(season_length, n)
-    season_vals[:season_samples] = y[-season_samples:]
+    if n >= season_length:
+        # Standard case: the last `season_length` observations form one
+        # complete season cycle. forecast[h] = season_vals[h % season_length]
+        # naturally aligns, since season_vals[k] holds y[n-season_length+k].
+        season_vals[:] = y[-season_length:]
+    else:
+        # Short-history case (#1140): right-align y in season_vals so the
+        # last observation lands in the last seasonal slot. Slots whose
+        # seasonal offset has no historical observation (index < 0) stay
+        # NaN. The previous behaviour left-aligned y[:n], which silently
+        # shifted every forecast by (season_length - n) periods.
+        season_vals[season_length - n:] = y
     out = _repeat_val_seas(season_vals=season_vals, h=h)
     fcst = {"mean": out}
     if fitted:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1163,6 +1163,26 @@ class TestSeasonalNaive:
             == "SeasonalNaive_custom"
         )
 
+    def test_short_history_seasonal_alignment(self):
+        """Regression for #1140 — when ``len(y) < season_length`` the previous
+        implementation left-aligned y[:n] in the season buffer, so the first
+        forecast was y[0] instead of NaN, shifting the entire seasonal
+        alignment by ``season_length - n`` periods. With y = 1..39 and
+        ``season_length=52``, horizon 0 has no historical match (NaN);
+        horizon 13 corresponds to the same seasonal slot as y[0] (=1.0);
+        horizon 51 corresponds to y[-1] (=39.0).
+        """
+        season_length = 52
+        n = 39
+        y = np.arange(1, n + 1, dtype=float)
+        sn = SeasonalNaive(season_length=season_length)
+        fc = sn.forecast(y=y, h=season_length, X=None, X_future=None, fitted=False)
+        mean = fc["mean"]
+        # First (season_length - n) horizons have no historical match → NaN.
+        assert np.all(np.isnan(mean[: season_length - n]))
+        # Subsequent horizons recover y, in order, ending at y[-1].
+        np.testing.assert_array_equal(mean[season_length - n :], y)
+
 
 class TestWindowAverage:
     def test_window_average(self):


### PR DESCRIPTION
## Summary

When ``len(y) < season_length``, ``_seasonal_naive`` left-aligned ``y[:n]`` in the season buffer. Horizon 0 then mapped to ``y[0]`` regardless of where ``y[0]`` actually sat in the season, shifting every forecast by ``season_length - n`` periods. Right-align ``y`` in the buffer so the last observation lands in the last seasonal slot; missing seasonal offsets stay NaN.

Fixes Nixtla/statsforecast#1140 — *SeasonalNaive: forecasts misalign with the seasonal period when len(y) < season_length*

## Context

``_seasonal_naive`` builds a ``season_vals`` array of length ``season_length``, then tiles it across the horizon: ``forecast[h] = season_vals[h % season_length]``. With a long history (``n >= season_length``) it stores ``y[-season_length:]`` in ``season_vals``, so ``season_vals[k] = y[n - season_length + k]`` and the seasonal alignment is correct by construction.

With a short history (``n < season_length``) the previous code did ``season_vals[:n] = y[-n:]``. That makes ``season_vals[0] = y[0]`` regardless of which seasonal slot ``y[0]`` belongs to. In the report's example (``y = 1..39``, ``season_length=52``, weekly data, first observation at week 14 of 2025) the user expects:

- horizon 0 (week 1 of 2026) → NaN, since week 1 has no historical observation.
- horizon 13 (week 14 of 2026) → ``y[0]`` (=1), the same week as the first historical observation.
- horizon 51 (week 52 of 2026) → ``y[-1]`` (=39), the same week as the last observation.

On origin/main the user instead got ``y[0]`` at horizon 0 (a 13-week shift) and NaN for the last 13 horizons.

The fix right-aligns ``y`` in the buffer: ``season_vals[season_length - n:] = y``. Slots ``[0, season_length - n)`` stay NaN. The standard-case branch (``n >= season_length``) is preserved bit-identically.

## Changes

- ``python/statsforecast/utils.py`` — split ``_seasonal_naive`` into the standard and short-history branches with an inline comment explaining the alignment invariant. The branch carries a reference to #1140 so a reviewer reading the diff cold can see why the special case exists.
- ``tests/test_models.py`` — new ``TestSeasonalNaive::test_short_history_seasonal_alignment`` regression: builds the report's exact scenario (``y = 1..39``, ``season_length = 52``) and asserts (a) the first 13 horizons are NaN and (b) horizons 13..51 recover ``y`` in order.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/Nixtla/statsforecast.git /tmp/sf-1140 && cd /tmp/sf-1140
git submodule update --init --recursive
python -m venv .venv && source .venv/bin/activate
pip install --no-build-isolation -e . pytest

REPRO='
import numpy as np
from statsforecast.models import SeasonalNaive

season_length, n = 52, 39
y = np.arange(1, n + 1, dtype=float)
fc = SeasonalNaive(season_length=season_length).forecast(
    y=y, h=season_length, X=None, X_future=None, fitted=False,
)
mean = fc["mean"]
# Horizon 0 corresponds to the same seasonal slot as week 1 of 2026,
# which has no matching historical observation -> must be NaN.
assert np.isnan(mean[0]), f"horizon 0 should be NaN, got {mean[0]}"
# Horizon 13 corresponds to the same seasonal slot as y[0]=1 -> must be 1.
assert mean[13] == 1.0, f"horizon 13 should be 1.0, got {mean[13]}"
# Horizon 51 corresponds to y[-1]=39 -> must be 39.
assert mean[51] == 39.0, f"horizon 51 should be 39.0, got {mean[51]}"
print("OK")
'

# --- BEFORE (origin/main) ---
git checkout origin/main
python -c "$REPRO"
# Expected: AssertionError "horizon 0 should be NaN, got 1.0"

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/statsforecast.git feat/1140-seasonal-naive-align
git checkout FETCH_HEAD
python -c "$REPRO"
# Expected: prints OK
```

## What I ran locally

- ``pytest tests/test_models.py::TestSeasonalNaive -v --no-cov`` → **8/8 passed** (was 7; 8th is the new regression).
- ``pytest tests/test_models.py tests/test_simulation_distributions.py -q --no-cov -k Seasonal`` → **21/21 passed**, no behavioural regression on the standard ``n >= season_length`` path.
- Stashing the source change makes ``test_short_history_seasonal_alignment`` fail on origin/main with ``assert np.all(np.isnan(...))`` against ``[1, 2, ..., 13]`` — the exact misalignment the report describes.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | ``n < season_length`` (the report) | ``y = 1..39``, ``season_length = 52`` | first 13 horizons NaN, then 1..39 | ``test_short_history_seasonal_alignment`` |
| 2 | ``n >= season_length`` (standard path) | AirPassengers, ``season_length=12``, h=12 | bit-identical to origin/main | existing ``test_seasonal_naive``, ``test_seasonal_naive_forecast``, ``test_seasonal_naive_big_h`` |
| 3 | Forward + conformal paths | AirPassengers + ``ConformalIntervals`` | unchanged | existing ``test_seasonal_naive_forward``, ``test_seasonal_naive_conformal_prediction`` |
| 4 | Distributed simulation distributions | season_length=12 in simulation tests | unchanged | existing ``test_simulation_distributions::*Seasonal*`` |

## Risk / blast radius

The standard case (``n >= season_length``) is bit-identical: I replaced the ``season_samples = min(...)`` slice with the equivalent ``y[-season_length:]`` direct slice on the same branch. Only the previously-broken short-history path changes behaviour. Users who were working around the bug by passing only complete-season histories see no diff.

## Release note

```release-note
fix(seasonal-naive): correctly align forecasts with the seasonal period when the input series is shorter than `season_length`. Slots without a matching historical observation now return NaN instead of silently using a shifted earlier observation.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against the alignment invariant ``forecast[h] = y[n - season_length + (h % season_length)]`` and the existing standard-case branch. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*