### PR TITLE
fix: align SeasonalNaive forecasts when len(y) < season_length

### DIFF
--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -236,8 +236,15 @@ def _seasonal_naive(
     y = _ensure_float(y)
     n = y.size
     season_vals = np.full(season_length, np.nan, dtype=y.dtype)
-    season_samples = min(season_length, n)
-    season_vals[:season_samples] = y[-season_samples:]
+    n_available = min(season_length, n)
+    if n < season_length:
+        # Partial season: align observations to their seasonal positions
+        # so that the forecast cycles correctly from the start of the season.
+        # y[-1] maps to the last position, filling backward.
+        start_idx = season_length - n_available
+        season_vals[start_idx:] = y[-n_available:]
+    else:
+        season_vals[:n_available] = y[-n_available:]
     out = _repeat_val_seas(season_vals=season_vals, h=h)
     fcst = {"mean": out}
     if fitted:

--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from typing import Dict
 
 import numpy as np
+import warnings
 import pandas as pd
 from scipy.stats import norm
 from utilsforecast.compat import DataFrame
@@ -241,6 +242,11 @@ def _seasonal_naive(
         # Partial season: align observations to their seasonal positions
         # so that the forecast cycles correctly from the start of the season.
         # y[-1] maps to the last position, filling backward.
+        warnings.warn(
+            f"Historical data ({n} obs) is shorter than season_length "
+            f"({season_length}). Forecasts for positions without "
+            f"corresponding observations will be NaN."
+        )
         start_idx = season_length - n_available
         season_vals[start_idx:] = y[-n_available:]
     else:

--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -2,11 +2,11 @@ __all__ = ['AirPassengers', 'AirPassengersDF', 'generate_series']
 
 
 import math
+import warnings
 from collections import namedtuple
 from typing import Dict
 
 import numpy as np
-import warnings
 import pandas as pd
 from scipy.stats import norm
 from utilsforecast.compat import DataFrame
@@ -240,12 +240,11 @@ def _seasonal_naive(
     n_available = min(season_length, n)
     if n < season_length:
         # Partial season: align observations to their seasonal positions
-        # so that the forecast cycles correctly from the start of the season.
-        # y[-1] maps to the last position, filling backward.
+        # so that the forecast cycles correctly. 
         warnings.warn(
-            f"Historical data ({n} obs) is shorter than season_length "
+            f"Historical data ({n}) is shorter than season_length "
             f"({season_length}). Forecasts for positions without "
-            f"corresponding observations will be NaN."
+            f"observations will be filled with NaN."
         )
         start_idx = season_length - n_available
         season_vals[start_idx:] = y[-n_available:]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,3 +53,32 @@ def test_seasonal_naive():
     np.testing.assert_equal(
         seas_naive_fcst["fitted"], np.hstack([np.full(12, np.nan), y[:11]])
     )
+
+def test_seasonal_naive_partial_season():
+    """Regression test for #1140: SeasonalNaive with len(y) < season_length."""
+    import numpy as np
+    from statsforecast.utils import _seasonal_naive
+    import warnings
+    
+    # 4 observations, 12-period season
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = _seasonal_naive(y=y, h=24, season_length=12, fitted=False)
+    
+    fcst = result["mean"]
+    
+    # Positions 0-7 should be NaN (no data for those seasonal positions)
+    assert np.isnan(fcst[0])
+    assert np.isnan(fcst[7])
+    
+    # Position 8-11 should be [1,2,3,4] (aligned correctly)
+    assert np.isclose(fcst[8], 1.0)
+    assert np.isclose(fcst[9], 2.0)
+    assert np.isclose(fcst[10], 3.0)
+    assert np.isclose(fcst[11], 4.0)
+    
+    # Warning should be emitted
+    assert len(w) >= 1, "No warning emitted for partial season"
+    assert "shorter than season_length" in str(w[0].message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from statsforecast.utils import _seasonal_naive
 
@@ -55,30 +57,17 @@ def test_seasonal_naive():
     )
 
 def test_seasonal_naive_partial_season():
-    """Regression test for #1140: SeasonalNaive with len(y) < season_length."""
-    import numpy as np
-    from statsforecast.utils import _seasonal_naive
-    import warnings
-    
-    # 4 observations, 12-period season
+    # test seasonal naive when the number of observations is shorter than the season length 
     y = np.array([1.0, 2.0, 3.0, 4.0])
-    
+
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         result = _seasonal_naive(y=y, h=24, season_length=12, fitted=False)
-    
-    fcst = result["mean"]
-    
-    # Positions 0-7 should be NaN (no data for those seasonal positions)
-    assert np.isnan(fcst[0])
-    assert np.isnan(fcst[7])
-    
-    # Position 8-11 should be [1,2,3,4] (aligned correctly)
-    assert np.isclose(fcst[8], 1.0)
-    assert np.isclose(fcst[9], 2.0)
-    assert np.isclose(fcst[10], 3.0)
-    assert np.isclose(fcst[11], 4.0)
-    
-    # Warning should be emitted
-    assert len(w) >= 1, "No warning emitted for partial season"
-    assert "shorter than season_length" in str(w[0].message)
+
+    expected = np.array(
+        [np.nan] * 8 + [1.0, 2.0, 3.0, 4.0] + [np.nan] * 8 + [1.0, 2.0, 3.0, 4.0]
+    )
+    np.testing.assert_array_equal(result["mean"], expected)
+
+    assert len(w) >= 1
+    assert "shorter than season_length" in str(w[-1].message)


### PR DESCRIPTION
Carries the fix from #1143 by @robrui (closes #1140), plus small cleanups to match StatsForecast conventions

Closes #1140. Supersedes #1143.