### PR TITLE
fix: add new level validation method 

### DIFF
--- a/python/statsforecast/core.py
+++ b/python/statsforecast/core.py
@@ -714,7 +714,16 @@ class _StatsForecast:
     def _validate_level(level: Optional[List[int]]) -> None:
         if level is None or len(level) == 0:
             return
-        arr = np.asarray(level)
+        try:
+            arr = np.asarray(level, dtype=float)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Every value in `level` must be a finite real number. Got: {list(level)}"
+            )
+        if not np.isfinite(arr).all():
+            raise ValueError(
+                f"Every value in `level` must be a finite real number. Got: {list(level)}"
+            )
         if np.any((arr <= 0) | (arr >= 100)):
             raise ValueError(
                 "Every value in `level` must be between 0 and 100 (exclusive). "

--- a/python/statsforecast/core.py
+++ b/python/statsforecast/core.py
@@ -710,9 +710,21 @@ class _StatsForecast:
             df = df.reset_index(drop=True)
         return df
 
+    @staticmethod
+    def _validate_level(level: Optional[List[int]]) -> None:
+        if level is None or len(level) == 0:
+            return
+        arr = np.asarray(level)
+        if np.any((arr <= 0) | (arr >= 100)):
+            raise ValueError(
+                "Every value in `level` must be between 0 and 100 (exclusive). "
+                f"Got: {list(level)}"
+            )
+
     def _parse_X_level(
         self, h: int, X: Optional[DataFrame], level: Optional[List[int]]
     ):
+        self._validate_level(level)
         if level is None:
             level = []
         if X is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -706,19 +706,17 @@ def test_for_monthly_data():
 def test_level_validation():
     # confidence levels must be between 0 and 100, exclusive
     sf = StatsForecast(models=[Naive()], freq="M", n_jobs=1)
-    msg = "Every value in `level` must be between 0 and 100"
+    msg = "Every value in `level` must be"
+    invalid_levels = [[0, 100], [-1], [101], [np.nan], [np.inf], ["a"]]
 
-    assert_raises_with_message(
-        sf.forecast, msg, df=ap_df, h=12, level=[0, 100]
-    )
-    assert_raises_with_message(
-        sf.cross_validation, msg, df=ap_df, h=12, n_windows=1, level=[0, 100]
-    )
-    assert_raises_with_message(
-        sf.fit_predict, msg, df=ap_df, h=12, level=[0, 100]
-    )
+    for level in invalid_levels:
+        assert_raises_with_message(sf.forecast, msg, df=ap_df, h=12, level=level)
+        assert_raises_with_message(sf.cross_validation, msg, df=ap_df, h=12, n_windows=1, level=level)
+        assert_raises_with_message(sf.fit_predict, msg, df=ap_df, h=12, level=level)
+    
     sf.fit(ap_df)
-    assert_raises_with_message(sf.predict, msg, h=12, level=[0, 100])
+    for level in invalid_levels:
+        assert_raises_with_message(sf.predict, msg, h=12, level=level)
 
     fcst = sf.forecast(df=ap_df, h=12, level=[80, 95])
     assert "Naive-lo-80" in fcst.columns and "Naive-hi-95" in fcst.columns

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -703,6 +703,37 @@ def test_for_monthly_data():
     )
 
 
+def test_level_validation():
+    # confidence levels must be between 0 and 100, exclusive
+    sf = StatsForecast(models=[Naive()], freq="M", n_jobs=1)
+    msg = "Every value in `level` must be between 0 and 100"
+
+    assert_raises_with_message(
+        sf.forecast, msg, df=ap_df, h=12, level=[0, 100]
+    )
+    assert_raises_with_message(
+        sf.cross_validation, msg, df=ap_df, h=12, n_windows=1, level=[0, 100]
+    )
+    assert_raises_with_message(
+        sf.fit_predict, msg, df=ap_df, h=12, level=[0, 100]
+    )
+    sf.fit(ap_df)
+    assert_raises_with_message(sf.predict, msg, h=12, level=[0, 100])
+
+    fcst = sf.forecast(df=ap_df, h=12, level=[80, 95])
+    assert "Naive-lo-80" in fcst.columns and "Naive-hi-95" in fcst.columns
+
+    cv = sf.cross_validation(df=ap_df, h=12, n_windows=1, level=[80, 95])
+    assert "Naive-lo-80" in cv.columns and "Naive-hi-95" in cv.columns
+
+    fp = sf.fit_predict(df=ap_df, h=12, level=[80, 95])
+    assert "Naive-lo-80" in fp.columns and "Naive-hi-95" in fp.columns
+
+    pred = sf.predict(h=12, level=[80, 95])
+    assert "Naive-lo-80" in pred.columns and "Naive-hi-95" in pred.columns
+
+
+
 # # StatsForecast.forecast_fitted_values method usage example
 
 # # from statsforecast.core import StatsForecast


### PR DESCRIPTION
## Description

Validates that the confidence levels set in `level` are between 0 and 100, exclusive. Fixes #482.

Previously, out-of-range values were accepted and produced invalid prediction intervals. 

This PR is an alternative implementation to #1146. It adds a `_validate_level` method on `_StatsForecast` and invokes it from `_parse_X_level`, the existing helper that `forecast`, `cross_validation`, `predict`, and `fit_predict` already route `level` through.

This keeps the check at the orchestration layer, runs it exactly once per public call, and keeps the change confined to `core.py`.

It also includes a test following the structure of the current testing suite.

Thanks to @jbbqqf for raising the issue and proposing the initial fix.