### PR TITLE
[FEAT] Add conformal_error prediction intervals method

### DIFF
--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -149,8 +149,9 @@ def _add_conformal_error_intervals(
 ) -> Dict:
     r"""
     Adds conformal intervals to the `fcst` dict based on conformal scores `cs`.
-    `level` should be already sorted. This strategy uses the quantiles of the
-    conformity scores as the error margin for the prediction intervals.
+    `level` should be already sorted. Uses the `lv / 100` quantile of the
+    absolute conformity scores as the error margin around `fcst["mean"]`.
+    Returns the modified `fcst` dict.
     """
     quantiles = {lv: np.quantile(cs, lv / 100, axis=0) for lv in level}
     for lv in reversed(level):
@@ -165,10 +166,10 @@ def _get_conformal_method(method: str):
         "conformal_distribution": _add_conformal_distribution_intervals,
         "conformal_error": _add_conformal_error_intervals,
     }
-    if method not in available_methods.keys():
+    if method not in available_methods:
         raise ValueError(
             f"prediction intervals method {method} not supported "
-            f"please choose one of {', '.join(available_methods.keys())}"
+            f"please choose one of {', '.join(available_methods)}"
         )
     return available_methods[method]
 

--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -142,10 +142,28 @@ def _add_conformal_distribution_intervals(
     return fcst
 
 
+def _add_conformal_error_intervals(
+    fcst: Dict,
+    cs: np.ndarray,
+    level: List[Union[int, float]],
+) -> Dict:
+    r"""
+    Adds conformal intervals to the `fcst` dict based on conformal scores `cs`.
+    `level` should be already sorted. This strategy uses the quantiles of the
+    conformity scores as the error margin for the prediction intervals.
+    """
+    for lv in level:
+        alpha = 100 - lv
+        margin = np.quantile(cs, 1 - alpha / 200, axis=0)
+        fcst[f"lo-{lv}"] = fcst["mean"] - margin
+        fcst[f"hi-{lv}"] = fcst["mean"] + margin
+    return fcst
+
+
 def _get_conformal_method(method: str):
     available_methods = {
         "conformal_distribution": _add_conformal_distribution_intervals,
-        # "conformal_error": _add_conformal_error_intervals,
+        "conformal_error": _add_conformal_error_intervals,
     }
     if method not in available_methods.keys():
         raise ValueError(

--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -152,11 +152,11 @@ def _add_conformal_error_intervals(
     `level` should be already sorted. This strategy uses the quantiles of the
     conformity scores as the error margin for the prediction intervals.
     """
+    quantiles = {lv: np.quantile(cs, lv / 100, axis=0) for lv in level}
+    for lv in reversed(level):
+        fcst[f"lo-{lv}"] = fcst["mean"] - quantiles[lv]
     for lv in level:
-        alpha = 100 - lv
-        margin = np.quantile(cs, 1 - alpha / 200, axis=0)
-        fcst[f"lo-{lv}"] = fcst["mean"] - margin
-        fcst[f"hi-{lv}"] = fcst["mean"] + margin
+        fcst[f"hi-{lv}"] = fcst["mean"] + quantiles[lv]
     return fcst
 
 

--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -348,6 +348,7 @@ class ConformalIntervals:
                 "You need at least two windows to compute conformal intervals"
             )
         allowed_methods = ["conformal_distribution", "conformal_error"]
+        # Keep in sync with _get_conformal_method's available_methods dict in models.py
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
         self.n_windows = n_windows

--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -334,7 +334,7 @@ class ConformalIntervals:
     Args:
         n_windows (int, optional): Number of windows for conformal intervals. Defaults to 2.
         h (int, optional): Forecasting horizon. Defaults to 1.
-        method (str, optional): Method for conformal intervals. Defaults to "conformal_distribution".
+        method (str, optional): Method for conformal intervals. Defaults to "conformal_distribution". Must be one of ["conformal_distribution", "conformal_error"].
     """
 
     def __init__(
@@ -347,7 +347,7 @@ class ConformalIntervals:
             raise ValueError(
                 "You need at least two windows to compute conformal intervals"
             )
-        allowed_methods = ["conformal_distribution"]
+        allowed_methods = ["conformal_distribution", "conformal_error"]
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
         self.n_windows = n_windows

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -752,6 +752,38 @@ def test_level_validation():
     assert "Naive-lo-80" in pred.columns and "Naive-hi-95" in pred.columns
 
 
+def test_conformal_error_end_to_end():
+    # end-to-end: conformal_error intervals flow through AutoARIMA and
+    # StatsForecast.forecast, producing valid, symmetric, monotone intervals
+    h = 12
+    level = [80, 90]
+    model = AutoARIMA(
+        season_length=12,
+        prediction_intervals=ConformalIntervals(
+            h=h, n_windows=2, method="conformal_error"
+        ),
+    )
+    sf = StatsForecast(models=[model], freq="M", n_jobs=1)
+    fcst = sf.forecast(df=ap_df, h=h, level=level)
+
+    m = repr(model)  # "AutoARIMA"
+    for lv in level:
+        assert f"{m}-lo-{lv}" in fcst.columns
+        assert f"{m}-hi-{lv}" in fcst.columns
+
+    mean = fcst[m].to_numpy()
+    lo80, hi80 = fcst[f"{m}-lo-80"].to_numpy(), fcst[f"{m}-hi-80"].to_numpy()
+    lo90, hi90 = fcst[f"{m}-lo-90"].to_numpy(), fcst[f"{m}-hi-90"].to_numpy()
+
+    # mean is bracketed by every interval
+    assert np.all(lo90 <= mean) and np.all(mean <= hi90)
+    # wider level => wider interval
+    assert np.all(hi90 >= hi80) and np.all(lo90 <= lo80)
+    # conformal_error adds a symmetric margin around the mean
+    np.testing.assert_allclose(hi80 - mean, mean - lo80)
+    np.testing.assert_allclose(hi90 - mean, mean - lo90)
+
+
 
 # # StatsForecast.forecast_fitted_values method usage example
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -143,6 +143,20 @@ def test_conformal_intervals():
     assert list(fcst_conformal.keys()) == ["mean", "lo-90", "lo-80", "hi-80", "hi-90"]
 
 
+def test_conformal_error_intervals():
+    """Test conformal_error method produces valid intervals."""
+    conf_intervals = ConformalIntervals(h=12, n_windows=10, method="conformal_error")
+    zero_model = ZeroModel(conf_intervals)
+    fcst = zero_model.forecast(ap, h=12, level=[80, 90])
+    # Check keys
+    assert list(fcst.keys()) == ["mean", "lo-90", "lo-80", "hi-80", "hi-90"]
+    # For ZeroModel (mean=0), intervals should be symmetric around 0
+    np.testing.assert_array_equal(fcst["lo-90"], -fcst["hi-90"])
+    np.testing.assert_array_equal(fcst["lo-80"], -fcst["hi-80"])
+    # Higher confidence = wider intervals
+    assert np.all(fcst["hi-90"] >= fcst["hi-80"])
+
+
 def assert_class(
     cls_,
     x,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -145,7 +145,7 @@ def test_conformal_intervals():
 
 def test_conformal_error_intervals():
     """Test conformal_error method produces valid intervals."""
-    conf_intervals = ConformalIntervals(h=12, n_windows=10, method="conformal_error")
+    conf_intervals = ConformalIntervals(h=12, n_windows=2, method="conformal_error")
     zero_model = ZeroModel(conf_intervals)
     fcst = zero_model.forecast(ap, h=12, level=[80, 90])
     # Check keys
@@ -155,13 +155,16 @@ def test_conformal_error_intervals():
     np.testing.assert_array_equal(fcst["lo-80"], -fcst["hi-80"])
     # Higher confidence = wider intervals
     assert np.all(fcst["hi-90"] >= fcst["hi-80"])
+    # Hi and lo are anti-symmetric (implied by the exact-value checks below).
     # Exact-value check: for ZeroModel (mean=0), conformal_error intervals
     # should match the lv/100 quantile of the conformity scores.
     cs = zero_model._conformity_scores(ap)
-    np.testing.assert_allclose(fcst["hi-90"], np.quantile(cs, 0.9, axis=0))
-    np.testing.assert_allclose(fcst["hi-80"], np.quantile(cs, 0.8, axis=0))
-    np.testing.assert_allclose(fcst["lo-90"], -np.quantile(cs, 0.9, axis=0))
-    np.testing.assert_allclose(fcst["lo-80"], -np.quantile(cs, 0.8, axis=0))
+    q90 = np.quantile(cs, 0.9, axis=0)
+    q80 = np.quantile(cs, 0.8, axis=0)
+    np.testing.assert_allclose(fcst["hi-90"], q90)
+    np.testing.assert_allclose(fcst["hi-80"], q80)
+    np.testing.assert_allclose(fcst["lo-90"], -q90)
+    np.testing.assert_allclose(fcst["lo-80"], -q80)
 
 
 def assert_class(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,10 +157,11 @@ def test_conformal_error_intervals():
     assert np.all(fcst["hi-90"] >= fcst["hi-80"])
     # Exact-value check: for ZeroModel (mean=0), conformal_error intervals
     # should match the lv/100 quantile of the conformity scores.
-    zero_model2 = ZeroModel(ConformalIntervals(h=12, n_windows=10, method="conformal_error"))
-    cs = zero_model2._conformity_scores(ap)
+    cs = zero_model._conformity_scores(ap)
     np.testing.assert_allclose(fcst["hi-90"], np.quantile(cs, 0.9, axis=0))
     np.testing.assert_allclose(fcst["hi-80"], np.quantile(cs, 0.8, axis=0))
+    np.testing.assert_allclose(fcst["lo-90"], -np.quantile(cs, 0.9, axis=0))
+    np.testing.assert_allclose(fcst["lo-80"], -np.quantile(cs, 0.8, axis=0))
 
 
 def assert_class(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -155,6 +155,12 @@ def test_conformal_error_intervals():
     np.testing.assert_array_equal(fcst["lo-80"], -fcst["hi-80"])
     # Higher confidence = wider intervals
     assert np.all(fcst["hi-90"] >= fcst["hi-80"])
+    # Exact-value check: for ZeroModel (mean=0), conformal_error intervals
+    # should match the lv/100 quantile of the conformity scores.
+    zero_model2 = ZeroModel(ConformalIntervals(h=12, n_windows=10, method="conformal_error"))
+    cs = zero_model2._conformity_scores(ap)
+    np.testing.assert_allclose(fcst["hi-90"], np.quantile(cs, 0.9, axis=0))
+    np.testing.assert_allclose(fcst["hi-80"], np.quantile(cs, 0.8, axis=0))
 
 
 def assert_class(


### PR DESCRIPTION
Adds the `conformal_error` prediction intervals method, which uses quantiles of the conformity scores as the error margin for prediction intervals. This is a companion to the existing `conformal_distribution` method.

Changes:
- Add `_add_conformal_error_intervals()` function to models.py
- Enable `"conformal_error"` in `_get_conformal_method()`
- Add test `test_conformal_error_intervals`