### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -38,7 +38,7 @@
       "login": "tackes",
       "name": "Jeff Tackes",
       "avatar_url": "https://avatars.githubusercontent.com/u/9125316?v=4",
-      "profile": "http://www.jefftackes.com",
+      "profile": "https://github.com/tackes",
       "contributions": [
         "bug"
       ]
@@ -291,7 +291,7 @@
       "login": "manuel-calzolari",
       "name": "Manuel Calzolari",
       "avatar_url": "https://avatars.githubusercontent.com/u/2764902?v=4",
-      "profile": "https://manuel.calzolari.name",
+      "profile": "https://github.com/manuel-calzolari",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ See [CONTRIBUTING.md](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBU
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/en/reference/emoji-key/)):
 
 <table>
   <tbody>
@@ -220,7 +220,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/AzulGarza"><img src="https://avatars.githubusercontent.com/u/10517170?v=4?s=100" width="100px;" alt="azul"/><br /><sub><b>azul</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=AzulGarza" title="Code">💻</a> <a href="#maintenance-AzulGarza" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/jmoralez"><img src="https://avatars.githubusercontent.com/u/8473587?v=4?s=100" width="100px;" alt="José Morales"/><br /><sub><b>José Morales</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=jmoralez" title="Code">💻</a> <a href="#maintenance-jmoralez" title="Maintenance">🚧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://www.linkedin.com/in/sugatoray/"><img src="https://avatars.githubusercontent.com/u/10201242?v=4?s=100" width="100px;" alt="Sugato Ray"/><br /><sub><b>Sugato Ray</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=sugatoray" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="http://www.jefftackes.com"><img src="https://avatars.githubusercontent.com/u/9125316?v=4?s=100" width="100px;" alt="Jeff Tackes"/><br /><sub><b>Jeff Tackes</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/issues?q=author%3Atackes" title="Bug reports">🐛</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/tackes"><img src="https://avatars.githubusercontent.com/u/9125316?v=4?s=100" width="100px;" alt="Jeff Tackes"/><br /><sub><b>Jeff Tackes</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/issues?q=author%3Atackes" title="Bug reports">🐛</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/darinkist"><img src="https://avatars.githubusercontent.com/u/62692170?v=4?s=100" width="100px;" alt="darinkist"/><br /><sub><b>darinkist</b></sub></a><br /><a href="#ideas-darinkist" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/alech97"><img src="https://avatars.githubusercontent.com/u/22159405?v=4?s=100" width="100px;" alt="Alec Helyar"/><br /><sub><b>Alec Helyar</b></sub></a><br /><a href="#question-alech97" title="Answering Questions">💬</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://dhirschfeld.github.io"><img src="https://avatars.githubusercontent.com/u/881019?v=4?s=100" width="100px;" alt="Dave Hirschfeld"/><br /><sub><b>Dave Hirschfeld</b></sub></a><br /><a href="#question-dhirschfeld" title="Answering Questions">💬</a></td>
@@ -256,7 +256,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/yibenhuang"><img src="https://avatars.githubusercontent.com/u/62163340?v=4?s=100" width="100px;" alt="Yiben Huang"/><br /><sub><b>Yiben Huang</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=yibenhuang" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/andrewgross"><img src="https://avatars.githubusercontent.com/u/370118?v=4?s=100" width="100px;" alt="Andrew Gross"/><br /><sub><b>Andrew Gross</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=andrewgross" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/taniishkaaa"><img src="https://avatars.githubusercontent.com/u/109246904?v=4?s=100" width="100px;" alt="taniishkaaa"/><br /><sub><b>taniishkaaa</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=taniishkaaa" title="Documentation">📖</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://manuel.calzolari.name"><img src="https://avatars.githubusercontent.com/u/2764902?v=4?s=100" width="100px;" alt="Manuel Calzolari"/><br /><sub><b>Manuel Calzolari</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=manuel-calzolari" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/manuel-calzolari"><img src="https://avatars.githubusercontent.com/u/2764902?v=4?s=100" width="100px;" alt="Manuel Calzolari"/><br /><sub><b>Manuel Calzolari</b></sub></a><br /><a href="https://github.com/Nixtla/statsforecast/commits?author=manuel-calzolari" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/nbs/docs/contribute/issue-labels.md
+++ b/nbs/docs/contribute/issue-labels.md
@@ -9,25 +9,19 @@ This segment delves into the variety of issue labels used within the [Nixtla Git
 
 Should you be a contributor now or in the future, it's important to take note of issues flagged with these labels.
 
-### The `first-timers-only` Label
-
-For those who have not yet contributed to Nixtla, start by looking for issues tagged as `first-timers-only`.
-
-Please review the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) before opening a pull request.
-
-You can browse all `first-timers-only` issues [here](https://github.com/Nixtla/statsforecast/labels/first-timers-only).
+Before opening a pull request, review the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) and sign our [Contributor License Agreement](https://cla-assistant.io/Nixtla/statsforecast).
 
 ### The `good first issue` Label
 
 Issues labeled as `good first issue` are ideal for newcomers.
 
-You can browse all `good first issue` issues [here](https://github.com/Nixtla/statsforecast/labels/good%20first%20issue).
+You can browse all `good first issue` issues [here](https://github.com/nixtla/nixtla/labels/good%20first%20issue).
 
 ### The `help wanted` Label
 
 Issues tagged as `help wanted` are open to anyone who wishes to contribute to Nixtla.
 
-You can browse all `help wanted` issues [here](https://github.com/Nixtla/statsforecast/labels/help%20wanted).
+You can browse all `help wanted` issues [here](https://github.com/nixtla/nixtla/labels/help%20wanted).
 
 ### The `bug` Label
 

--- a/nbs/docs/contribute/issue-labels.md
+++ b/nbs/docs/contribute/issue-labels.md
@@ -13,21 +13,21 @@ Should you be a contributor now or in the future, it's important to take note of
 
 For those who have not yet contributed to Nixtla, start by looking for issues tagged as `first-timers-only`.
 
-Please note that before we can accept your contribution to Nixtla, you'll need to sign our [Contributor License Agreement](https://github.com/nixtla/nixtla_native/blob/stable/assets/contributions-agreement/individual-contributor.md).
+Please review the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) before opening a pull request.
 
-You can browse all `first-timers-only` issues [here](https://github.com/nixtla/nixtla/labels/first-timers-only).
+You can browse all `first-timers-only` issues [here](https://github.com/Nixtla/statsforecast/labels/first-timers-only).
 
 ### The `good first issue` Label
 
 Issues labeled as `good first issue` are ideal for newcomers.
 
-You can browse all `good first issue` issues [here](https://github.com/nixtla/nixtla/labels/good%20first%20issue).
+You can browse all `good first issue` issues [here](https://github.com/Nixtla/statsforecast/labels/good%20first%20issue).
 
 ### The `help wanted` Label
 
 Issues tagged as `help wanted` are open to anyone who wishes to contribute to Nixtla.
 
-You can browse all `help wanted` issues [here](https://github.com/nixtla/nixtla/labels/help%20wanted).
+You can browse all `help wanted` issues [here](https://github.com/Nixtla/statsforecast/labels/help%20wanted).
 
 ### The `bug` Label
 

--- a/nbs/docs/contribute/issues.md
+++ b/nbs/docs/contribute/issues.md
@@ -3,13 +3,13 @@ title: Submit an Issue 📢
 sidebarTitle: Submit an Issue
 ---
 
-To report a bug, request a feature, propose a new integration, or suggest documentation improvements, please visit the [StatsForecast GitHub issues page](https://github.com/Nixtla/statsforecast/issues). Before submitting a new issue, kindly check if it has already been reported.
+To report a bug, request a feature, propose a new integration, or suggest documentation improvements, please visit the [Nixtla GitHub issues page](https://github.com/nixtla/nixtla/issues). Before submitting a new issue, kindly check if it has already been reported.
 
 ## Steps to Submit an Issue
 
 Here's a step-by-step guide on submitting an issue to the Nixtla repository.
 
-Visit [our GitHub issues page](https://github.com/Nixtla/statsforecast/issues) and click on the _New issue_ button.
+Visit [our GitHub issues page](https://github.com/nixtla/nixtla/issues) and click on the _New issue_ button.
 
 A list of available issue types will be displayed.
 

--- a/nbs/docs/contribute/issues.md
+++ b/nbs/docs/contribute/issues.md
@@ -3,13 +3,13 @@ title: Submit an Issue 📢
 sidebarTitle: Submit an Issue
 ---
 
-To report a bug, request a feature, propose a new integration, or suggest documentation improvements, please visit the [Nixtla GitHub issues page](https://github.com/nixtla/nixtla/issues). Before submitting a new issue, kindly check if it has already been reported.
+To report a bug, request a feature, propose a new integration, or suggest documentation improvements, please visit the [StatsForecast GitHub issues page](https://github.com/Nixtla/statsforecast/issues). Before submitting a new issue, kindly check if it has already been reported.
 
 ## Steps to Submit an Issue
 
 Here's a step-by-step guide on submitting an issue to the Nixtla repository.
 
-Visit [our GitHub issues page](https://github.com/nixtla/nixtla/issues) and click on the _New issue_ button.
+Visit [our GitHub issues page](https://github.com/Nixtla/statsforecast/issues) and click on the _New issue_ button.
 
 A list of available issue types will be displayed.
 
@@ -27,7 +27,7 @@ The form to report the bug will appear.
 
 <Info>
 
-Please ensure that your contributions abide by the [contributing guidelines](https://github.com/nixtla/nixtla/blob/staging/CONTRIBUTING.md) and [code of conduct](https://github.com/nixtla/nixtla/blob/staging/CODE_OF_CONDUCT.md).
+Please ensure that your contributions abide by the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Nixtla/statsforecast/blob/main/CODE_OF_CONDUCT.md).
 
 </Info>
 
@@ -46,7 +46,7 @@ The feature request form will appear.
 
 <Info>
 
-Please ensure that your contributions abide by the [contributing guidelines](https://github.com/nixtla/nixtla/blob/staging/CONTRIBUTING.md) and [code of conduct](https://github.com/nixtla/nixtla/blob/staging/CODE_OF_CONDUCT.md).
+Please ensure that your contributions abide by the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Nixtla/statsforecast/blob/main/CODE_OF_CONDUCT.md).
 
 </Info>
 
@@ -64,7 +64,7 @@ A form for suggesting improvements will appear.
 
 <Info>
 
-Please ensure that your contributions abide by the [contributing guidelines](https://github.com/nixtla/nixtla/blob/staging/CONTRIBUTING.md) and [code of conduct](https://github.com/nixtla/nixtla/blob/staging/CODE_OF_CONDUCT.md).
+Please ensure that your contributions abide by the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Nixtla/statsforecast/blob/main/CODE_OF_CONDUCT.md).
 
 </Info>
 
@@ -87,7 +87,7 @@ A form for your proposal will appear.
 
 <Info>
 
-Please ensure that your contributions abide by the [contributing guidelines](https://github.com/nixtla/nixtla/blob/staging/CONTRIBUTING.md) and [code of conduct](https://github.com/nixtla/nixtla/blob/staging/CODE_OF_CONDUCT.md).
+Please ensure that your contributions abide by the [contributing guidelines](https://github.com/Nixtla/statsforecast/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/Nixtla/statsforecast/blob/main/CODE_OF_CONDUCT.md).
 
 </Info>
 

--- a/nbs/docs/distributed/spark.ipynb
+++ b/nbs/docs/distributed/spark.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "StatsForecast works on top of Spark, Dask, and Ray through [Fugue](https://github.com/fugue-project/fugue/). StatsForecast will read the input DataFrame and use the corresponding engine. For example, if the input is a Spark DataFrame, StatsForecast will use the existing Spark session to run the forecast.\n",
     "\n",
-    "A benchmark (with older syntax) can be found [here](https://towardsdatascience.com/distributed-forecast-of-1m-time-series-in-under-15-minutes-with-spark-nixtla-and-fugue-e9892da6fd5c) where we forecasted one million timeseries in under 15 minutes."
+    "Current guidance for distributed forecasting with Spark is available in the [Fugue backend documentation](https://nixtlaverse.nixtla.io/statsforecast/src/core/distributed.fugue.html)."
    ]
   },
   {

--- a/nbs/docs/how-to-guides/Exogenous.ipynb
+++ b/nbs/docs/how-to-guides/Exogenous.ipynb
@@ -616,7 +616,7 @@
    "id": "f2133e1d-5b6e-4a91-8df3-97d6869b1559",
    "metadata": {},
    "source": [
-    "To generate the forecast, we'll use [AutoARIMA](https://nixtlaverse.nixtla.io/statsforecast/docs/models/AutoARIMA), which is one of the models available in StatsForecast that allows exogenous regressors. To use this model, we first need to import it from `statsforecast.models` and then we need to instantiate it. Given that we're working with daily data, we need to set `season_length = 7`. "
+    "To generate the forecast, we'll use [AutoARIMA](https://nixtlaverse.nixtla.io/statsforecast/src/core/models.html#autoarima), which is one of the models available in StatsForecast that allows exogenous regressors. To use this model, we first need to import it from `statsforecast.models` and then we need to instantiate it. Given that we're working with daily data, we need to set `season_length = 7`. "
    ]
   },
   {

--- a/nbs/docs/tutorials/ElectricityLoadForecasting.ipynb
+++ b/nbs/docs/tutorials/ElectricityLoadForecasting.ipynb
@@ -63,7 +63,7 @@
     "Some time series are generated from very low frequency data. These data generally exhibit multiple seasonalities. For example, hourly data may exhibit repeated patterns every hour (every 24 observations) or every day (every 24 * 7, hours per day, observations). This is the case for electricity load. Electricity load may vary hourly, e.g., during the evenings electricity consumption may be expected to increase. But also, the electricity load varies by week. Perhaps on weekends there is an increase in electrical activity.\n",
     "\n",
     "\n",
-    "In this example we will show how to model the two seasonalities of the time series to generate accurate forecasts in a short time. We will use hourly PJM electricity load data. The original data can be found [here](https://github.com/jnagura/Energy-consumption-prediction-analysis). "
+    "In this example we will show how to model the two seasonalities of the time series to generate accurate forecasts in a short time. We will use hourly PJM electricity load data. The original data can be found [here](https://github.com/panambY/Hourly_Energy_Consumption). "
    ]
   },
   {

--- a/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
+++ b/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
@@ -601,7 +601,7 @@
    "source": [
     "StatsForecast and MSTL in particular are good benchmarking models for peak detection. However, it might be useful to explore further and newer forecasting algorithms. We have seen particularly good results with the N-HiTS, a deep-learning model from Nixtla's NeuralForecast library.\n",
     "\n",
-    "Learn how to predict ERCOT demand peaks with our deep-learning N-HiTS model and the NeuralForecast library in [this tutorial](../../../neuralforecast/use-cases/electricitypeakforecasting.html)."
+    "Learn how to predict ERCOT demand peaks with our deep-learning N-HiTS model and the NeuralForecast library in [this tutorial](../../../neuralforecast/docs/use-cases/electricity_peak_forecasting.html)."
    ]
   },
   {

--- a/nbs/docs/tutorials/MultipleSeasonalities.ipynb
+++ b/nbs/docs/tutorials/MultipleSeasonalities.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "Traditional statistical models are not able to model more than one seasonal length. In this example, we will show how to model the two seasonalities efficiently using Multiple Seasonal-Trend decompositions with LOESS (`MSTL`). \n",
     "\n",
-    "For this example, we will use hourly electricity load data from Pennsylvania, New Jersey, and Maryland (PJM). The original data can be found [here](https://github.com/jnagura/Energy-consumption-prediction-analysis). (Click here for info on [PJM](https://www.pjm.com/about-pjm))\n",
+    "For this example, we will use hourly electricity load data from Pennsylvania, New Jersey, and Maryland (PJM). The original data can be found [here](https://github.com/panambY/Hourly_Energy_Consumption). (Click here for info on [PJM](https://www.pjm.com/about-pjm))\n",
     "\n",
     "First, we will load the data, then we will use the `StatsForecast.fit` and `StatsForecast.predict` methods to predict the next 24 hours. We will then decompose the different elements of the time series into trends and its multiple seasonalities. At the end, you will use the `StatsForecast.forecast` for production-ready forecasting. "
    ]

--- a/python/statsforecast/distributed/fugue.py
+++ b/python/statsforecast/distributed/fugue.py
@@ -53,7 +53,7 @@ def _cotransform(
 
 class FugueBackend(ParallelBackend):
     """FugueBackend for Distributed Computation.
-    [Source code](https://github.com/Nixtla/statsforecast/blob/main/statsforecast/distributed/fugue.py).
+    [Source code](https://github.com/Nixtla/statsforecast/blob/main/python/statsforecast/distributed/fugue.py).
 
     This class uses [Fugue](https://github.com/fugue-project/fugue) backend capable of distributing
     computation on Spark, Dask and Ray without any rewrites.


### PR DESCRIPTION
## What

Repairs broken StatsForecast documentation routes, images, contributor links, data references, source links, and the Contributor License Agreement destination.

## Why

The published documentation contained stale routes, an incorrectly resolved image, removed sites and repositories, and a dead Contributor License Agreement link.

## How

1. Point product links at current Nixtlaverse pages and anchors.
2. Correct the cross validation image path and Fugue source path.
3. Replace retired external destinations with current official documentation, repository files, contributor profiles, and the data repository used by the notebooks.
4. Preserve the requirement to sign the Contributor License Agreement and link it to the active CLA Assistant flow for StatsForecast.
5. Remove guidance for the nonexistent `first-timers-only` label and leave working Nixtla issue links unchanged.
6. Keep `.all-contributorsrc` consistent with the generated contributor table.

## Testing

1. Requested the CLA Assistant destination, contributing guide, restored issue links, and restored label links three times and received HTTP 200 each time.
2. Confirmed recent StatsForecast pull requests report successful `license/cla` checks through the same CLA Assistant flow.
3. Confirmed the `good first issue` and `help wanted` labels exist and `first-timers-only` does not exist in StatsForecast.
4. Ran `git diff --check`, reviewed the complete diff, and scanned for secrets and unintended artifacts.

## Checklist

1. [x] Title follows conventional commit format.
2. [x] The PR is limited to documentation links and assets.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data were added.
