### PR TITLE
docs: improve statistical model search metadata

### DIFF
--- a/nbs/docs/models/HoltWinters.ipynb
+++ b/nbs/docs/models/HoltWinters.ipynb
@@ -34,8 +34,6 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "# Holt Winters Model\n",
-                "\n",
                 "> Step-by-step guide on using the `Holt Winters Model` with `Statsforecast`.\n",
                 "\n",
                 "During this walkthrough, we will become familiar with the main `StatsForecast` class and some relevant methods such as `StatsForecast.plot`, `StatsForecast.forecast` and `StatsForecast.cross_validation` in other.\n",

--- a/nbs/docs/models/HoltWinters.ipynb
+++ b/nbs/docs/models/HoltWinters.ipynb
@@ -1,6 +1,16 @@
 {
     "cells": [
         {
+            "cell_type": "raw",
+            "metadata": {},
+            "source": [
+                "---\n",
+                "title: Holt Winters Time Series Forecasting in Python\n",
+                "description: Learn Holt Winters forecasting with StatsForecast, including level, trend, seasonality, model selection, and cross validation.\n",
+                "---"
+            ]
+        },
+        {
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},

--- a/nbs/docs/tutorials/CrossValidation.ipynb
+++ b/nbs/docs/tutorials/CrossValidation.ipynb
@@ -14,8 +14,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Cross validation | StatsForecast\n",
-    "\n",
     "> In this example, we'll implement time series cross-validation to evaluate model's performance. "
    ]
   },

--- a/nbs/docs/tutorials/CrossValidation.ipynb
+++ b/nbs/docs/tutorials/CrossValidation.ipynb
@@ -1,6 +1,16 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: Time Series Cross Validation with StatsForecast\n",
+    "description: Evaluate statistical forecasting models with rolling time series cross validation. Configure horizons, windows, and accuracy metrics in StatsForecast.\n",
+    "---"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/nbs/docs/tutorials/GARCH_tutorial.ipynb
+++ b/nbs/docs/tutorials/GARCH_tutorial.ipynb
@@ -17,8 +17,6 @@
    "id": "05332e29-553e-48d8-b15d-b7874495b672",
    "metadata": {},
    "source": [
-    "# Volatility forecasting (GARCH & ARCH)\n",
-    "\n",
     "> In this example, we'll forecast the volatility of the S&P 500 and several publicly traded companies using GARCH and ARCH models"
    ]
   },

--- a/nbs/docs/tutorials/GARCH_tutorial.ipynb
+++ b/nbs/docs/tutorials/GARCH_tutorial.ipynb
@@ -1,6 +1,17 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "id": "garch-search-metadata",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: GARCH and ARCH Volatility Forecasting in Python\n",
+    "description: Forecast stock market volatility with GARCH and ARCH models in StatsForecast. Load returns, fit models, evaluate forecasts, and visualize results.\n",
+    "---"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "05332e29-553e-48d8-b15d-b7874495b672",


### PR DESCRIPTION
## What

* Adds focused search titles and descriptions to the GARCH and Holt Winters model notebooks.
* Adds focused search metadata to the GARCH and cross validation tutorials.

## Why

The pages rank for high impression explanatory queries, but their current snippets do not clearly state the forecasting task, Python workflow, or evaluation content.

## How

The new raw frontmatter cells describe the exact page purpose while leaving notebook content and execution unchanged.

## Testing

* Parsed every changed notebook with `jq`.
* Converted all four notebooks through `jupyter nbconvert` to validate notebook structure.
* Ran `git diff --check`.

## Checklist

* [x] Existing routes remain unchanged.
* [x] Metadata matches current StatsForecast behavior.
* [x] No unsupported performance claims added.
