### PR TITLE
arima: implement bootstrap prediction intervals in forecast_arima

### DIFF
--- a/python/statsforecast/arima.py
+++ b/python/statsforecast/arima.py
@@ -1480,6 +1480,11 @@ def forecast_arima(
     if fan:
         level = np.arange(51, 100, 3)
 
+    # Future regressors as provided by the caller, before the drift column is
+    # appended below. simulate_arima adds the drift term itself, so bootstrap
+    # intervals must pass these regressors, not the drift-augmented ones.
+    orig_xreg = xreg
+
     if use_drift:
         n = len(x)
         drift = np.arange(1, h + 1, dtype=np.float64).reshape(-1, 1)
@@ -1508,7 +1513,31 @@ def forecast_arima(
     if level is not None:
         # nint = len(level)
         if bootstrap:
-            raise NotImplementedError("bootstrap=True")
+            # Empirical prediction intervals: simulate future sample paths by
+            # resampling the in-sample residuals (the standard bootstrap PI
+            # method), then take the empirical quantiles. Uses the existing
+            # simulate_arima infrastructure instead of the parametric formula.
+            if model.get("residuals") is None:
+                raise ValueError(
+                    "bootstrap=True requires the fitted model to store residuals"
+                )
+            paths = simulate_arima(
+                model,
+                h=h,
+                n_paths=npaths,
+                xreg=orig_xreg,
+                error_distribution="bootstrap",
+            )
+            lower_q = [(1 - lv / 100) / 2 for lv in level]
+            upper_q = [(1 + lv / 100) / 2 for lv in level]
+            lower = pd.DataFrame(
+                np.quantile(paths, lower_q, axis=0).T,
+                columns=[f"{l}%" for l in level],
+            )
+            upper = pd.DataFrame(
+                np.quantile(paths, upper_q, axis=0).T,
+                columns=[f"{l}%" for l in level],
+            )
         else:
             dist = model.get("distribution", Distribution.NORMAL)
             quantiles = _quantiles(level, distribution=dist, dist_params=error_params_from_model(model))

--- a/tests/test_arima.py
+++ b/tests/test_arima.py
@@ -525,6 +525,26 @@ def test_forecast_arima_confidence_intervals(res_Arima_s):
     assert fcst["upper"].shape[1] == 17
 
 
+def test_forecast_arima_bootstrap_intervals(res_Arima_s):
+    """bootstrap=True yields empirical prediction intervals instead of raising (#1191)."""
+    fcst = forecast_arima(
+        res_Arima_s, h=12, level=(80, 95), bootstrap=True, npaths=2000
+    )
+    assert fcst["lower"].columns.tolist() == ["80%", "95%"]
+    assert fcst["upper"].columns.tolist() == ["80%", "95%"]
+
+    lower80 = fcst["lower"]["80%"].to_numpy()
+    lower95 = fcst["lower"]["95%"].to_numpy()
+    upper80 = fcst["upper"]["80%"].to_numpy()
+    upper95 = fcst["upper"]["95%"].to_numpy()
+    mean = np.asarray(fcst["mean"])
+
+    # Finite, brackets the mean, and the 80% band sits inside the 95% band.
+    assert np.all(np.isfinite(lower95)) and np.all(np.isfinite(upper95))
+    assert np.all(lower95 <= mean) and np.all(mean <= upper95)
+    assert np.all(lower95 <= lower80) and np.all(upper80 <= upper95)
+
+
 def test_fitted_arima_lengths(res_Arima, res_Arima_ex, res_Arima_s):
     """Test that fitted_arima returns correct lengths for different models."""
 


### PR DESCRIPTION
## Summary

`forecast_arima(..., bootstrap=True)` raised `NotImplementedError("bootstrap=True")`, even
though the bootstrap simulation infrastructure already exists
(`simulate_arima(..., error_distribution="bootstrap")`, which resamples the in-sample
residuals). This PR wires that infrastructure in so `bootstrap=True` produces empirical
prediction intervals instead of raising. Addresses #1191 (the ARIMA part).

## What it does

When `bootstrap=True`, instead of the parametric `pred ± q·se` formula, `forecast_arima`
now simulates `npaths` future sample paths by resampling the fitted residuals
(`simulate_arima(..., error_distribution="bootstrap")`) and takes the empirical quantiles
for each requested `level`. This is the standard empirical/bootstrap prediction-interval
method (Hyndman & Athanasopoulos, *Forecasting: Principles and Practice*; the same approach
as R's `forecast::forecast(bootstrap=TRUE)`), implemented natively with the library's own
`simulate_arima`/`sample_errors` — no external code.

Notes:
- The caller's future `xreg` (before the internal drift column is appended) is passed to
  `simulate_arima`, which adds the drift term itself, so drift is not double-counted.
- A clear `ValueError` is raised if the fitted model does not store residuals.
- Output shape and columns (`["80%", "95%"]`, etc.) match the parametric branch.

## Verification

```python
model = AutoARIMA(season_length=1).fit(y).model_
fb = forecast_arima(model, h=12, level=[80, 95], bootstrap=True)   # no longer raises
```

- New test `test_forecast_arima_bootstrap_intervals`: intervals are finite, bracket the
  mean, and the 80% band sits inside the 95% band.
- All 47 existing `tests/test_arima.py` tests still pass.
- `ruff check`/`ruff format` clean on the changed lines.

## Follow-up

The issue also mentions the `bootstrap` argument being unused in the ETS path
(`pegelsfcast_C`). Wiring bootstrap through the ETS interval computation (routing the
analytic classes through the existing simulation path) is more involved and left as a
follow-up so this PR stays focused on the ARIMA `NotImplementedError`.
