### PR TITLE
fix: return the constant as fitted values for a constant series in fitted_arima

### DIFF
--- a/python/statsforecast/arima.py
+++ b/python/statsforecast/arima.py
@@ -1685,6 +1685,11 @@ def fitted_arima(model, h=1):
             return model.get("fitted")
         elif x is None:
             return None
+        elif is_constant(x):
+            # A zero-mean model fitted to a constant series has residuals equal
+            # to the series, so ``x - residuals`` would be all zeros. The fitted
+            # values are the constant itself, matching forecast_arima.
+            return np.repeat(x[0], len(x))
         elif model.get("lambda") is None:
             return x - model["residuals"]
         else:

--- a/tests/test_arima.py
+++ b/tests/test_arima.py
@@ -475,6 +475,18 @@ def test_Arima_drift_and_residuals():
     )
 
 
+def test_fitted_arima_constant_series():
+    """Fitted values of a constant series must be the constant, not zeros.
+
+    A zero-mean model (allowmean=False) fitted to a constant series has
+    residuals equal to the series, so the previous ``x - residuals`` returned
+    all zeros instead of the constant.
+    """
+    x = np.full(36, 7.0)
+    model = auto_arima_f(x, allowmean=False)
+    np.testing.assert_allclose(fitted_arima(model), x)
+
+
 def test_Arima_with_exogenous_variables(res_Arima_ex):
     """Test Arima model with exogenous variables and residuals consistency."""
     drift = np.arange(1, ap.size + 1).reshape(-1, 1)


### PR DESCRIPTION
Closes #870.

## Problem

`forecast_fitted_values()` returns 0 for every in-sample point of a constant
series, instead of the constant:

```python
df = pd.DataFrame({'unique_id': 0, 'ds': range(100), 'y': np.full(100, 7.0)})
sf = StatsForecast(models=[AutoARIMA(allowmean=False)], freq=1)
sf.forecast(h=1, df=df, fitted=True)
sf.forecast_fitted_values()['AutoARIMA']   # all 0.0, should be 7.0
```

When AutoARIMA selects a zero-mean model for a constant series, the residuals
equal the series, so `fitted_arima`'s `x - residuals` is all zeros. The
out-of-sample forecast is already correct because `forecast_arima` special-cases
a constant series with `is_constant(x)`; `fitted_arima` did not.

## Fix

Add the same `is_constant(x)` branch to `fitted_arima`, returning the constant.

## Verification

With the fix, fitted values equal the constant for both `allowmean=False` and
`allowmean=True`, and non-constant series are unchanged (fitted values still
track the series). Added a regression test that fails without the change; the
full `test_arima.py` suite (49 tests) passes.
