### PR TITLE
fix: avoid excessive ARIMA covariance workspace

### DIFF
--- a/python/statsforecast/arima.py
+++ b/python/statsforecast/arima.py
@@ -22,6 +22,7 @@ import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 from coreforecast.scalers import boxcox, boxcox_lambda, inv_boxcox
+from scipy.linalg import solve_discrete_lyapunov
 from scipy.optimize import minimize
 from scipy.signal import convolve
 from scipy.stats import norm
@@ -64,9 +65,11 @@ def getQ0(phi, theta):
     p = len(phi)
     q = len(theta)
     r = max(p, q + 1)
-    res = np.zeros(r * r, dtype=np.float64)
-    _arima.getQ0(phi, theta, res)
-    return res.reshape(r, r)
+    transition = np.zeros((r, r))
+    transition[:p, 0] = phi
+    transition[:-1, 1:] = np.eye(r - 1)
+    noise = np.pad(np.concatenate(([1.0], theta)), (0, r - q - 1))
+    return solve_discrete_lyapunov(transition, np.outer(noise, noise))
 
 
 def arima_transpar(params_in, arma, trans):

--- a/tests/test_arima.py
+++ b/tests/test_arima.py
@@ -109,6 +109,20 @@ def test_getQ0():
     np.testing.assert_allclose(expected_getQ0, getQ0(x, x))
 
 
+def test_arima_high_seasonal_order():
+    fixed = {"sar1": 0.1, **{f"sma{i}": 0.01 for i in range(1, 8)}}
+    y = np.sin(np.arange(96) * 2 * np.pi / 48)
+    model = ARIMA(
+        order=(0, 0, 0),
+        season_length=48,
+        seasonal_order=(1, 1, 7),
+        method="ML",
+        fixed=fixed,
+    ).fit(y)
+
+    assert np.isfinite(model.predict(1)["mean"]).all()
+
+
 @pytest.fixture
 def expected_arima_transpar_f():
     expected_arima_transpar_f = (


### PR DESCRIPTION
Title: fix: avoid excessive ARIMA covariance workspace

## Summary

- Compute the ARIMA initial state covariance with SciPy's discrete Lyapunov solver.
- Avoid the native temporary vector whose size grows roughly as the fourth power of the expanded ARMA order.
- Add a regression for the reported `(0, 0, 0)(1, 1, 7)[48]` fit and prediction.

Fixes #1034

## Test evidence

- The existing `getQ0` expected-value regression passes against the replacement.
- A focused 337-state assertion produces a finite covariance satisfying the discrete Lyapunov equation.
- Python compilation, Ruff on the changed production file, and `git diff --check` pass.
- The added fit-level pytest test awaits CI because local dependency setup could not obtain the CPython 3.12 `coreforecast` wheel in the network-restricted sandbox.

## Risks or notes for maintainers

High-order ARIMA optimization remains computationally expensive, but covariance initialization no longer requires the failing O(r⁴) workspace. SciPy is already a required dependency.
