### PR TITLE
fix: preserve the full MFLES seasonal cycle

### DIFF
--- a/python/statsforecast/mfles.py
+++ b/python/statsforecast/mfles.py
@@ -422,7 +422,7 @@ class MFLES:
             ma_cycle = itertools.cycle(ma)
         if seasonal_period is not None:
             seasons_cycle = itertools.cycle(list(range(len(seasonal_period))))
-            self.seasonality = np.zeros(max(seasonal_period))
+            self.seasonality = np.zeros(np.lcm.reduce(seasonal_period))
             fourier_series = []
             for period in seasonal_period:
                 if fourier_order is None:

--- a/tests/test_mfles.py
+++ b/tests/test_mfles.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pandas as pd
 from statsforecast.mfles import MFLES
+from statsforecast.models import MFLES as ModelMFLES
 
 
 class TestMFLES:
@@ -51,3 +53,16 @@ class TestMFLES:
         assert fitted is not None
         assert predicted is not None
         assert len(predicted) == 24
+
+
+def test_mfles_multiseasonal_forecast_uses_full_cycle():
+    season_1 = np.array([0, 100])
+    season_2 = np.array([0, -200, 0, 0, 0])
+    y = np.resize(season_1, 30) + np.resize(season_2, 30)
+
+    model = ModelMFLES(season_length=[2, 5], trend_lr=0, residuals_lr=0)
+    model.fit(y)
+    forecast = model.predict(10)["mean"]
+
+    # The combined seasonality repeats every lcm(2, 5) observations.
+    np.testing.assert_allclose(forecast[5] - forecast[0], 100, atol=1)


### PR DESCRIPTION
## Summary

MFLES now stores the combined seasonal pattern over the least common multiple of all configured periods. This prevents forecasts from truncating the pattern when the largest period is not divisible by the smaller periods.

Closes #938.

## Tests

- Added a regression test for seasonal periods 2 and 5
- Verified the regression fails before the fix and passes afterward
- Verified single, duplicate, and nested seasonal periods, plus serialization
- Ruff and `git diff --check`

The seasonal buffer is now proportional to the periods’ LCM; configurations where one period divides another retain their existing size.