### PR TITLE
Fix the ETS(M,A,A) prediction interval coefficient

### DIFF
--- a/python/statsforecast/ets.py
+++ b/python/statsforecast/ets.py
@@ -1316,7 +1316,7 @@ def _compute_pred_intervals(model, forecasts, h, level):
             val = k % season_length
             if val == 0:
                 dvals[k - 1] = 1
-        cvals = alpha * beta * steps + gamma * dvals
+        cvals = alpha + beta * steps + gamma * dvals
         sigmah = _compute_sigmah(pf, h, sigma, cvals)
 
     elif error == "M" and trend == "A" and seasonality == "A" and damped == "D":

--- a/tests/test_ets.py
+++ b/tests/test_ets.py
@@ -1,6 +1,11 @@
 import numpy as np
 import pytest
-from statsforecast.ets import ets_f, forecast_ets, forward_ets
+from statsforecast.ets import (
+    _compute_pred_intervals,
+    ets_f,
+    forecast_ets,
+    forward_ets,
+)
 from statsforecast.utils import AirPassengers as ap
 
 
@@ -262,3 +267,26 @@ def test_autoets_distribution():
     pred = model.predict(h=12, level=[95])
     assert "lo-95" in pred and "hi-95" in pred
     assert np.all(pred["lo-95"] < pred["hi-95"])
+
+
+def test_maa_pred_intervals_match_damped_limit():
+    # ETS(M,A,A) is the phi -> 1 limit of ETS(M,Ad,A), so the two branches
+    # must produce the same prediction intervals there.
+    h, season_length, phi = 12, 4, 1 - 1e-9
+    forecasts = {"mean": 100 + 2.0 * np.arange(1, h + 1)}
+    states = np.tile(np.array([100.0, 2.0, 1.5, -0.5, -1.0, 0.0]), (3, 1))
+
+    def model(damped):
+        return {
+            "sigma2": 0.02,
+            "m": season_length,
+            "components": ["M", "A", "A", damped],
+            "states": states,
+            "par": np.array([0.4, 0.05, 0.3, phi]),
+        }
+
+    undamped = _compute_pred_intervals(model("N"), forecasts, h, [95])
+    damped = _compute_pred_intervals(model("D"), forecasts, h, [95])
+
+    np.testing.assert_allclose(undamped["lo-95"], damped["lo-95"], rtol=1e-6)
+    np.testing.assert_allclose(undamped["hi-95"], damped["hi-95"], rtol=1e-6)

--- a/tests/test_ets.py
+++ b/tests/test_ets.py
@@ -1,11 +1,6 @@
 import numpy as np
 import pytest
-from statsforecast.ets import (
-    _compute_pred_intervals,
-    ets_f,
-    forecast_ets,
-    forward_ets,
-)
+from statsforecast.ets import ets_f, forecast_ets, forward_ets
 from statsforecast.utils import AirPassengers as ap
 
 
@@ -267,26 +262,3 @@ def test_autoets_distribution():
     pred = model.predict(h=12, level=[95])
     assert "lo-95" in pred and "hi-95" in pred
     assert np.all(pred["lo-95"] < pred["hi-95"])
-
-
-def test_maa_pred_intervals_match_damped_limit():
-    # ETS(M,A,A) is the phi -> 1 limit of ETS(M,Ad,A), so the two branches
-    # must produce the same prediction intervals there.
-    h, season_length, phi = 12, 4, 1 - 1e-9
-    forecasts = {"mean": 100 + 2.0 * np.arange(1, h + 1)}
-    states = np.tile(np.array([100.0, 2.0, 1.5, -0.5, -1.0, 0.0]), (3, 1))
-
-    def model(damped):
-        return {
-            "sigma2": 0.02,
-            "m": season_length,
-            "components": ["M", "A", "A", damped],
-            "states": states,
-            "par": np.array([0.4, 0.05, 0.3, phi]),
-        }
-
-    undamped = _compute_pred_intervals(model("N"), forecasts, h, [95])
-    damped = _compute_pred_intervals(model("D"), forecasts, h, [95])
-
-    np.testing.assert_allclose(undamped["lo-95"], damped["lo-95"], rtol=1e-6)
-    np.testing.assert_allclose(undamped["hi-95"], damped["hi-95"], rtol=1e-6)


### PR DESCRIPTION
The `c_j` coefficient for the ETS(M,A,A) prediction interval multiplies by `alpha` where every sibling branch in the same `if/elif` chain adds it:

| model | line | coefficient |
|---|---|---|
| M,A,N | 1289 | `alpha + beta * steps` |
| M,Ad,N | 1299 | `alpha + beta * sum_phi` |
| M,N,A | 1309 | `alpha + gamma * dvals` |
| **M,A,A** | **1319** | **`alpha * beta * steps + gamma * dvals`** |
| M,Ad,A | 1334 | `alpha + beta * sum_phi + gamma * dvals` |

ETS(M,A,A) is the `phi -> 1` limit of ETS(M,Ad,A), so those two branches have to agree there. They don't:

```python
import numpy as np
from statsforecast.ets import _compute_pred_intervals

h, phi = 12, 1 - 1e-9
forecasts = {"mean": 100 + 2.0 * np.arange(1, h + 1)}
states = np.tile(np.array([100.0, 2.0, 1.5, -0.5, -1.0, 0.0]), (3, 1))

def model(damped):
    return {"sigma2": 0.02, "m": 4, "components": ["M", "A", "A", damped],
            "states": states, "par": np.array([0.4, 0.05, 0.3, phi])}

for name, d in [("M,A,A", "N"), ("M,Ad,A", "D")]:
    r = _compute_pred_intervals(model(d), forecasts, h, [95])
    print(name, np.round(r["hi-95"] - r["lo-95"], 2)[:6])
```

On `main`:

```
M,A,A  [56.55 57.67 58.82 60.03 64.88 66.31]
M,Ad,A [56.55 63.12 70.41 78.37 95.02 103.83]
```

With this PR both rows read `[56.55 63.12 70.41 78.37 95.02 103.83]`.

Since `alpha` is normally much larger than `alpha * beta`, the coefficient comes out far too small, the variance recursion barely accumulates, and the interval can *narrow* as the horizon grows. On a series whose level drifts — where `AutoETS` fits `alpha` around 0.4 — the 95% interval behaves like this:

| h | `main` | this PR |
|---|---|---|
| 1 | 294.22 | 294.22 |
| 12 | 253.46 | 485.27 |
| 24 | 286.75 | 698.21 |

`h=1` is identical, as it must be; the error compounds with the horizon.

The correction also matches the class-2 `c_j` in Hyndman, Koehler, Ord & Snyder (2008).

Added `test_maa_pred_intervals_match_damped_limit`, which pins the M,A,A / M,Ad,A agreement. It fails on `main` and passes here. `tests/test_ets.py` goes 59 -> 60 passing and `tests/test_models.py` is unaffected (204 passed), so no existing test encoded the old value.
