### PR TITLE
docs: fix remaining language errors

### DIFF
--- a/nbs/docs/experiments/ETS_ray_m5.ipynb
+++ b/nbs/docs/experiments/ETS_ray_m5.ipynb
@@ -177,7 +177,7 @@
    "id": "9a3065dc-a8f5-4ad0-be2a-39d5330d4369",
    "metadata": {},
    "source": [
-    "Since the M5 dataset contains intermittent time series, we add a constant to avoid problems during the training phase. Later, we will substract the constant from the forecasts."
+    "Since the M5 dataset contains intermittent time series, we add a constant to avoid problems during the training phase. Later, we will subtract the constant from the forecasts."
    ]
   },
   {

--- a/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
+++ b/nbs/docs/tutorials/ElectricityPeakForecasting.ipynb
@@ -478,7 +478,7 @@
    "metadata": {},
    "source": [
     ":::{.callout-important}\n",
-    "When using `cross_validation` make sure the forecasts are produced at the desired timestamps. Check the `cutoff` column which specifices the last timestamp before the forecasting window.\n",
+    "When using `cross_validation` make sure the forecasts are produced at the desired timestamps. Check the `cutoff` column which specifies the last timestamp before the forecasting window.\n",
     ":::"
    ]
   },


### PR DESCRIPTION
## What

Fix two objective spelling errors in the published StatsForecast documentation.

## Why

The current experiment and tutorial pages contain misspelled verbs. The corrections preserve the technical meaning.

## How

1. Change substract to subtract.
2. Change specifices to specifies.

## Testing

1. [x] Parsed both modified notebooks as valid JSON.
2. [x] Confirmed the reported misspellings are absent from the affected files.
3. [x] Reviewed the complete diff.
4. [x] Confirmed no secrets, credentials, or generated binaries are included.

## Checklist

1. [x] The title follows the conventional commit format.
2. [x] The pull request is focused on one concern.
3. [x] The complete diff was reviewed.
4. [x] No secrets, credentials, or personal data are included.