### PR TITLE
docs: fix workflow typo in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Sometimes, diving into a new technology can be challenging and overwhelming. We'
 - [Step-by-step Contribution Guide](#step-by-step-contribution-guide)
   - [Table of Contents 📚](#table-of-contents-)
   - [Prerequisites](#prerequisites)
-  - [Git `fork-and-pull` worklow](#git-fork-and-pull-worklow)
+  - [Git `fork-and-pull` workflow](#git-fork-and-pull-workflow)
   - [Set Up a Virtual Environment](#set-up-a-virtual-environment)
   - [Install required libraries for development](#install-required-libraries-for-development)
     - [Setup pre-commit hooks](#setup-pre-commit-hooks)
@@ -26,7 +26,7 @@ Sometimes, diving into a new technology can be challenging and overwhelming. We'
 - **GitHub**: You should already have a GitHub account and a basic understanding of its functionalities. Alternatively check [this guide](https://docs.github.com/en/get-started).
 - **uv**: You need to have `uv` installed. You can refer to the [docs](https://docs.astral.sh/uv/getting-started/installation/) in order to install it.
 
-## Git `fork-and-pull` worklow
+## Git `fork-and-pull` workflow
 
 **1. Fork the Project:**
 Start by forking the Nixtla repository to your own GitHub account. This creates a personal copy of the project where you can make changes without affecting the main repository.

--- a/nbs/docs/contribute/step-by-step.md
+++ b/nbs/docs/contribute/step-by-step.md
@@ -8,7 +8,7 @@ Sometimes, diving into a new technology can be challenging and overwhelming. We'
 ## Table of Contents 📚
 
 1. [Prerequisites](#prerequisites)
-2. [Git `fork-and-pull` worklow](#git-fork-and-pull-worklow)
+2. [Git `fork-and-pull` workflow](#git-fork-and-pull-workflow)
 3. [Set Up a Conda Environment](#set-up-a-conda-environment)
 4. [Install required libraries for development](#install-required-libraries-for-development)
 5. [Start editable mode](#start-editable-mode)
@@ -22,7 +22,7 @@ Sometimes, diving into a new technology can be challenging and overwhelming. We'
 - *Python*: Python should be installed on your system. Alternatively check [this guide](https://www.python.org/downloads/). 
 - *conda*: You need to have conda installed, along with a good grasp of fundamental operations such as creating environments, and activating and deactivating them.  Alternatively check [this guide](https://conda.io/projects/conda/en/latest/user-guide/install/index.html). 
 
-## Git `fork-and-pull` worklow
+## Git `fork-and-pull` workflow
 
 **1. Fork the Project:** 
 Start by forking the Nixtla repository to your own GitHub account. This creates a personal copy of the project where you can make changes without affecting the main repository.


### PR DESCRIPTION
## What

Corrects `worklow` to `workflow` in the contribution guide headings and their table-of-contents links.

## Why

The typo appears in both copies of the guide and produces a misspelled section anchor.

## How

- Update the heading text.
- Update the matching table-of-contents anchors.

## Testing

- [x] Confirmed `worklow` no longer appears in the two edited guides.
- [x] Confirmed each table-of-contents anchor matches its corrected heading.
- [x] Ran `git diff --check`.
