### PR TITLE
Validate ConformalIntervals horizon

### DIFF
--- a/python/statsforecast/utils.py
+++ b/python/statsforecast/utils.py
@@ -351,6 +351,8 @@ class ConformalIntervals:
         # Keep in sync with _get_conformal_method's available_methods dict in models.py
         if method not in allowed_methods:
             raise ValueError(f"method must be one of {allowed_methods}")
+        if h < 1:
+            raise ValueError(f"h must be at least 1, got {h}")
         self.n_windows = n_windows
         self.h = h
         self.method = method

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -143,6 +143,12 @@ def test_conformal_intervals():
     assert list(fcst_conformal.keys()) == ["mean", "lo-90", "lo-80", "hi-80", "hi-90"]
 
 
+@pytest.mark.parametrize("h", [0, -1])
+def test_conformal_intervals_invalid_h(h):
+    with pytest.raises(ValueError, match="h must be at least 1"):
+        ConformalIntervals(h=h)
+
+
 def test_conformal_error_intervals():
     """Test conformal_error method produces valid intervals."""
     conf_intervals = ConformalIntervals(h=12, n_windows=2, method="conformal_error")


### PR DESCRIPTION
## Summary

- reject non-positive `ConformalIntervals` horizons at construction time
- add regression coverage for zero and negative horizons

## Why

A non-positive horizon currently reaches `_conformity_scores`, where `h=0` raises a bare `ZeroDivisionError`. Failing at configuration time makes the invalid input clear and avoids an unrelated-looking downstream error.

## Tests

- `uv run pytest tests/test_models.py --no-cov -q` — 206 passed
- `uv run ruff check python/statsforecast/utils.py tests/test_models.py`

Fixes #1221