### PR TITLE
docs: fix typos in AutoETS/AutoCES docstrings and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or
 conda install -c conda-forge statsforecast
 ```
 
-Vist our [Installation Guide](https://nixtlaverse.nixtla.io/statsforecast/docs/getting-started/installation.html) for further instructions.
+Visit our [Installation Guide](https://nixtlaverse.nixtla.io/statsforecast/docs/getting-started/installation.html) for further instructions.
 
 ## Quick Start
 

--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -199,7 +199,7 @@ class _TS:
         n_windows = min(n_windows, (n_samples - 1) // h)
         if n_windows < 2:
             raise ValueError(
-                f"Prediction intervals settings require at least {2 * h + 1:,} samples, serie has {n_samples:,}."
+                f"Prediction intervals settings require at least {2 * h + 1:,} samples, series has {n_samples:,}."
             )
         test_size = n_windows * h
         cs = np.empty((n_windows, h), dtype=y.dtype)
@@ -710,7 +710,7 @@ class AutoETS(_TS):
     Automatically selects the best ETS (Error, Trend, Seasonality)
     model using an information criterion. Default is Akaike Information Criterion (AICc), while particular models are estimated using maximum likelihood.
     The state-space equations can be determined based on their $M$ multiplicative, $A$ additive,
-    $Z$ optimized or $N$ ommited components. The `model` string parameter defines the ETS equations:
+    $Z$ optimized or $N$ omitted components. The `model` string parameter defines the ETS equations:
     E in [$M, A, Z$], T in [$N, A, M, Z$], and S in [$N, A, M, Z$].
 
     For example when model='ANN' (additive error, no trend, and no seasonality), ETS will
@@ -1014,9 +1014,9 @@ class AutoCES(_TS):
     Automatically selects the best Complex Exponential Smoothing
     model using an information criterion. Default is Akaike Information Criterion (AICc), while particular
     models are estimated using maximum likelihood.
-    The state-space equations can be determined based on their $S$ simple, $P$ parial,
-    $Z$ optimized or $N$ ommited components. The `model` string parameter defines the
-    kind of CES model: $N$ for simple CES (withous seasonality), $S$ for simple seasonality (lagged CES),
+    The state-space equations can be determined based on their $S$ simple, $P$ partial,
+    $Z$ optimized or $N$ omitted components. The `model` string parameter defines the
+    kind of CES model: $N$ for simple CES (without seasonality), $S$ for simple seasonality (lagged CES),
     $P$ for partial seasonality (without complex part), $F$ for full seasonality (lagged CES
     with real and complex seasonal parts).
 


### PR DESCRIPTION
## Description

Fixes six spelling mistakes: five in the `AutoETS` / `AutoCES` docstrings and the model-name validation message, plus one in the README. No identifiers or logic are touched.

| Location | Fix |
| --- | --- |
| `models.py:713` (`AutoETS`) | `$N$ ommited components` → `omitted` |
| `models.py:1017` (`AutoCES`) | `$P$ parial` → `partial` |
| `models.py:1018` (`AutoCES`) | `$N$ ommited components` → `omitted` |
| `models.py:1019` (`AutoCES`) | `simple CES (withous seasonality)` → `without` |
| `models.py:202` | `"...samples, serie has {n_samples:,}."` → `series` |
| `README.md:38` | `Vist our [Installation Guide]` → `Visit` |

Two of these are self-evident from their immediate surroundings — the same `AutoCES` docstring already writes `partial` correctly on line 1020 (`$P$ for partial seasonality`), and line 1019 itself writes `without` correctly later in the same sentence (`without complex part`).

`models.py:202` is a message users see: it is raised when there aren't enough samples for prediction intervals.

The four docstring fixes appear on the generated `AutoETS` and `AutoCES` API pages.

## How I checked

Candidates came from a spellcheck pass, then each was read in context. `serie` was confirmed to appear exactly once under `python/` (everywhere else the code says `series`), so it is a genuine slip rather than house style. Conversely, `lik`, `ans` and `nd` — which a spellchecker also flags in `arima.py` / `ets.py` / `ces.py` — are real variable names carried over from the R implementation and were left alone.

`python -m py_compile` passes on `models.py`. Documentation only, no functional change.

I checked the open documentation PRs for overlap: #1096 also touches `python/statsforecast/models.py`, but its changes are in the `SimpleExponentialSmoothing` / `SeasonalExponentialSmoothing` region (from line ~2246) and do not touch any of the lines above; #1217 and #1220 touch notebooks and `CONTRIBUTING.md` only.

_Disclosure: prepared with AI assistance; each occurrence was read in context and verified manually._
