### PR TITLE
docs: document both ConformalSeasonalPool interval thresholds and validate n_samples

### DIFF
--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -4267,8 +4267,9 @@ class ConformalSeasonalPool(_TS):
         Args:
             season_length (int): Number of observations per unit of time. Ex: 12 for monthly data.
             n_samples (int, default=100): Number of mixture samples used to estimate prediction intervals.
-                For a level-L interval, at least ``ceil(2/(1 - L/100)) - 1`` samples are needed before
-                the orientation-corrected lower bound is non-degenerate (e.g., ≥40 for a 95% interval).
+                For a level-L interval (with ``a = 1 - L/100``), at least ``ceil(2/a) - 1`` samples are
+                needed before the orientation-corrected lower bound is non-degenerate, and ``ceil(4/a) - 1``
+                before the upper bound is (e.g., ≥39 and ≥79 respectively for a 95% interval).
             variant (str, default="adaptive"): ``"adaptive"`` adjusts the mixture weight based on
                 seasonality and history depth; ``"fixed"`` always uses w=0.5.
             calib_frac (float, default=0.5): Fraction of training history used for calibration
@@ -4284,6 +4285,8 @@ class ConformalSeasonalPool(_TS):
         """
         if variant not in ("adaptive", "fixed"):
             raise ValueError("variant must be 'adaptive' or 'fixed'")
+        if n_samples < 1:
+            raise ValueError("n_samples must be a positive integer")
         self.season_length = season_length
         self.n_samples = n_samples
         self.variant = variant
@@ -4388,6 +4391,13 @@ class ConformalSeasonalPool(_TS):
         Point forecasts are seasonal naive fitted values. Prediction intervals
         are constant-width bands derived from the empirical quantiles of the
         calibration residuals R, centred on the fitted values.
+
+        Note:
+            The interval width here depends on the calibration pool size ``R.size``
+            (set by ``calib_frac`` and the history length), not on ``n_samples``.
+            For a level-L interval (with ``a = 1 - L/100``), the orientation-corrected
+            offsets are non-degenerate only once ``R.size`` reaches ``ceil(2/a) - 1``
+            (lower) and ``ceil(4/a) - 1`` (upper).
 
         Args:
             level (List[float]): Confidence levels (0-100) for prediction intervals.

--- a/tests/test_csp.py
+++ b/tests/test_csp.py
@@ -157,6 +157,13 @@ def test_invalid_variant_raises():
         ConformalSeasonalPool(season_length=12, variant="bogus")
 
 
+# n_samples below 1 is rejected (see #1202); n_samples=1 stays allowed
+@pytest.mark.parametrize("n_samples", [0, -1])
+def test_invalid_n_samples_raises(n_samples):
+    with pytest.raises(ValueError, match="n_samples"):
+        ConformalSeasonalPool(season_length=12, n_samples=n_samples)
+
+
 def test_short_series_no_index_error():
     """n < season_length: forecast must not raise; NaN slots filled via latest-obs fallback."""
     m = 12


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #1202 (items 1–3).

#### What does this implement/fix? Explain your changes.

Addresses the mechanical items from @shivamlalakiya's detailed analysis in #1202:

1. **`n_samples` docstring:** it documented only the lower-bound threshold and its 95% example was off by one. It now gives both thresholds — `ceil(2/a) - 1` (lower bound) and `ceil(4/a) - 1` (upper bound), with `a = 1 - L/100` — and the worked example reads ≥39 / ≥79.
2. **`predict_in_sample`:** added a note that its interval width depends on the calibration pool size `R.size` (set by `calib_frac` and the history length), not on `n_samples`.
3. **`__init__`:** now rejects `n_samples < 1` (0 produced a degenerate, zero-width interval); `n_samples=1` stays allowed.

Item 4 (a runtime `warnings.warn` when the pool is below the threshold for a requested level) is a behaviour addition and is left to the maintainers' discretion, as the reporter noted.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### Testing

Added `test_invalid_n_samples_raises`; verified it fails without the guard. `ruff` and the `test_csp.py` suite (23 tests) are green.

Thanks to @shivamlalakiya for the thorough analysis.