### PR TITLE
Index the per-season alpha in the seasonal ES models

### DIFF
--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -2802,7 +2802,8 @@ class SeasonalExponentialSmoothing(_TS):
             m = self.season_length
             steps = np.arange(1, h + 1)
             k = ((steps - 1) // m) + 1
-            sigmah = sigma * np.sqrt(1 + (k - 1) * alpha**2)
+            alpha_h = alpha[(steps - 1) % m]
+            sigmah = sigma * np.sqrt(1 + (k - 1) * alpha_h**2)
             pred_int = _calculate_intervals(res, level, h, sigmah)
             res = {**res, **pred_int}
         return res
@@ -2852,7 +2853,9 @@ class SeasonalExponentialSmoothing(_TS):
         for i in range(h):
             s_idx = i % m
             paths[:, i] = levels[:, s_idx] + errors[:, i]
-            levels[:, s_idx] = alpha * paths[:, i] + (1 - alpha) * levels[:, s_idx]
+            levels[:, s_idx] = (
+                alpha[s_idx] * paths[:, i] + (1 - alpha[s_idx]) * levels[:, s_idx]
+            )
 
         return paths
 
@@ -3030,7 +3033,8 @@ class SeasonalExponentialSmoothingOptimized(_TS):
             m = self.season_length
             steps = np.arange(1, h + 1)
             k = ((steps - 1) // m) + 1
-            sigmah = sigma * np.sqrt(1 + (k - 1) * alpha**2)
+            alpha_h = alpha[(steps - 1) % m]
+            sigmah = sigma * np.sqrt(1 + (k - 1) * alpha_h**2)
             pred_int = _calculate_intervals(res, level, h, sigmah)
             res = {**res, **pred_int}
         return res
@@ -3080,7 +3084,9 @@ class SeasonalExponentialSmoothingOptimized(_TS):
         for i in range(h):
             s_idx = i % m
             paths[:, i] = levels[:, s_idx] + errors[:, i]
-            levels[:, s_idx] = alpha * paths[:, i] + (1 - alpha) * levels[:, s_idx]
+            levels[:, s_idx] = (
+                alpha[s_idx] * paths[:, i] + (1 - alpha[s_idx]) * levels[:, s_idx]
+            )
 
         return paths
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -658,6 +658,24 @@ class TestSES:
 
 
 class TestSeasonalES:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            SeasonalExponentialSmoothing(season_length=12, alpha=0.1),
+            SeasonalExponentialSmoothingOptimized(season_length=12),
+        ],
+    )
+    def test_prediction_intervals_and_simulate(self, model):
+        # `alpha` is one value per season here, so it has to be indexed.
+        model.fit(ap)
+
+        res = model.predict(h=6, level=[80])
+        assert res["lo-80"].shape == (6,)
+        assert np.all(res["lo-80"] <= res["mean"])
+        assert np.all(res["mean"] <= res["hi-80"])
+
+        assert model.simulate(h=6, n_paths=4).shape == (4, 6)
+
     def test_seasonal_es(self):
         seas_es = SeasonalExponentialSmoothing(season_length=12, alpha=1.0)
         assert_class(seas_es, x=ap, h=12)


### PR DESCRIPTION
`SeasonalExponentialSmoothing` and `SeasonalExponentialSmoothingOptimized` fit one alpha per season, so `model_["alpha"]` has shape `(season_length,)`. Two places were copied from the scalar `SimpleExponentialSmoothing` and use it unindexed, so both raise:

```python
m = SeasonalExponentialSmoothing(season_length=12, alpha=0.1)
m.fit(y)

m.predict(h=6, level=[80])
# ValueError: operands could not be broadcast together with shapes (6,) (12,)

m.simulate(h=6, n_paths=4)
# ValueError: operands could not be broadcast together with shapes (12,) (4,)
```

Both variants are affected; the scalar `SimpleExponentialSmoothing` works, and the only difference is the shape of `alpha`:

```
SeasonalExponentialSmoothing            alpha shape (12,)   predict(level) raises   simulate raises
SeasonalExponentialSmoothingOptimized   alpha shape (12,)   predict(level) raises   simulate raises
SimpleExponentialSmoothing              alpha shape ()      predict(level) OK       simulate OK
```

For `predict`, the interval needs the alpha of the season each step falls in. `k = ((steps - 1) // m) + 1` on the line above already gives the cycle number, so the season index is `(steps - 1) % m`.

For `simulate`, `s_idx = i % m` is already computed on the previous line for `levels`, and `alpha` needs the same index.

Scope:

- The scalar models are untouched. Their `alpha` is 0-d and their equivalent lines read differently (`levels = alpha * ...`, no `[:, s_idx]`), so they cannot be caught by this change — verified their `predict(level=...)` and `simulate` output is identical before and after.
- Point forecasts are identical before and after for all four models. Only the two paths that raised now return values.
- `tests/test_models.py` is 204 passed both before and after this change, since nothing that previously worked is touched.

Added a parametrised test covering both variants: it checks `predict(h, level=[80])` returns ordered bounds and that `simulate` returns the expected shape. It fails on `main` for both and passes here.

Worth noting these paths appear never to have worked — the seasonal `predict(level=...)` and `simulate` have raised since they were added.
