### PR TITLE
fix: validate level support for conformal-only interval models

### DIFF
--- a/python/statsforecast/core.py
+++ b/python/statsforecast/core.py
@@ -734,10 +734,28 @@ class _StatsForecast:
                 f"Got: {list(level)}"
             )
 
+    def _validate_level_support(self, level: Optional[List[int]]) -> None:
+        if level is None or len(level) == 0:
+            return
+        unsupported = [
+            repr(model)
+            for model in self.models
+            if getattr(model, "only_conformal_intervals", False)
+            and getattr(model, "prediction_intervals", None) is None
+        ]
+        if unsupported:
+            raise ValueError(
+                "`level` was provided but the following models can only compute "
+                f"prediction intervals through conformal prediction: {unsupported}. "
+                "Configure `prediction_intervals=ConformalIntervals(...)` before "
+                "requesting `level`, or remove `level`."
+            )
+
     def _parse_X_level(
         self, h: int, X: Optional[DataFrame], level: Optional[List[int]]
     ):
         self._validate_level(level)
+        self._validate_level_support(level)
         if level is None:
             level = []
         if X is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -630,6 +630,55 @@ class TestModels:
         fcst._set_prediction_intervals(None)
         assert models[0].prediction_intervals is not None
 
+    def test_level_requires_conformal_intervals(self):
+        df = pd.DataFrame(
+            {
+                "unique_id": np.repeat([1, 2], 50),
+                "ds": np.tile(pd.date_range("2020-01-01", periods=50), 2),
+                "y": np.arange(100, dtype=np.float64),
+            }
+        )
+        expected_msg = "can only compute prediction intervals through conformal"
+        for method in ("forecast", "cross_validation"):
+            fcst = StatsForecast(models=[WindowAverage(window_size=5)], freq="D")
+            with pytest.raises(ValueError, match=expected_msg):
+                getattr(fcst, method)(df=df, h=3, level=[80])
+        fcst = StatsForecast(models=[WindowAverage(window_size=5)], freq="D")
+        with pytest.raises(ValueError, match=expected_msg):
+            fcst.fit_predict(df=df, h=3, level=[80])
+        fcst.fit(df=df)
+        with pytest.raises(ValueError, match=expected_msg):
+            fcst.predict(h=3, level=[80])
+        fcst = StatsForecast(
+            models=[Naive(), WindowAverage(window_size=5, alias="WA")], freq="D"
+        )
+        with pytest.raises(ValueError, match=r"\['WA'\]"):
+            fcst.forecast(df=df, h=3, level=[80])
+        fcst = StatsForecast(
+            models=[WindowAverage(window_size=5)], freq="D", fallback_model=Naive()
+        )
+        with pytest.raises(ValueError, match=expected_msg):
+            fcst.forecast(df=df, h=3, level=[80])
+        fcst = StatsForecast(models=[WindowAverage(window_size=5)], freq="D")
+        res = fcst.forecast(df=df, h=3)
+        assert list(res.columns) == ["unique_id", "ds", "WindowAverage"]
+        intervals = ConformalIntervals(h=3, n_windows=2)
+        fcst = StatsForecast(
+            models=[WindowAverage(window_size=5, prediction_intervals=intervals)],
+            freq="D",
+        )
+        interval_cols = ["WindowAverage-lo-80", "WindowAverage-hi-80"]
+        res = fcst.forecast(df=df, h=3, level=[80])
+        assert res[interval_cols].notna().all().all()
+        fcst = StatsForecast(models=[WindowAverage(window_size=5)], freq="D")
+        res = fcst.forecast(df=df, h=3, level=[80], prediction_intervals=intervals)
+        assert res[interval_cols].notna().all().all()
+        fcst = StatsForecast(models=[WindowAverage(window_size=5)], freq="D")
+        fcst.fit(df=df, prediction_intervals=intervals)
+        res = fcst.predict(h=3, level=[80])
+        assert res[interval_cols].notna().all().all()
+        assert (res["WindowAverage-lo-80"] <= res["WindowAverage-hi-80"]).all()
+
 
 # fcst = StatsForecast(
 #     models=[AutoARIMA(season_length=7)], freq="D", n_jobs=1, verbose=True


### PR DESCRIPTION
## Issue

This PR fixes how `StatsForecast` handles `level` for models that only support prediction intervals through conformal prediction.

Several models declare `only_conformal_intervals = True`, but `core.py` does not currently use this flag. As a result, `level` is forwarded even when no `prediction_intervals` are configured.

This causes two problems:

* Without `fallback_model`, forecasting fails late with `Exception: You must pass prediction_intervals to compute them.`
* With `fallback_model`, the error is swallowed and fallback intervals can be returned under the original model's column names (for example, `WindowAverage-lo-80` containing intervals produced by `Naive`).

```python
sf = StatsForecast(
    models=[WindowAverage(window_size=5)],
    freq="D",
    fallback_model=Naive(),
)
sf.forecast(df=df, h=3, level=[80])
```

Closes #237

## What changed

* Added `_StatsForecast._validate_level_support` to raise a clear `ValueError` when `level` is requested for a conformal-only model without configured `prediction_intervals`.
* Validation runs from `_parse_X_level`, after `_set_prediction_intervals`, so it covers `predict`, `fit_predict`, `forecast`, and `cross_validation`.
* Added regression tests covering all four entry points, fallback behavior, mixed models, calls without `level`, and valid conformal interval configurations.

```bash
pytest tests/test_core.py -k test_level_requires_conformal_intervals
```

## Why this matters

Removing `level` from these models, as suggested in #237, would be a breaking change and would remove valid functionality when `ConformalIntervals` is configured.

This validation keeps the API intact while turning a late failure, or silently misleading fallback output, into an explicit error before forecasting begins.
