### PR TITLE
hotfix: GARCH analytical prediction interval formula

### DIFF
--- a/python/statsforecast/models.py
+++ b/python/statsforecast/models.py
@@ -6672,8 +6672,9 @@ class GARCH(_TS):
             res = self._add_predict_conformal_intervals(res, level)
         else:
             quantiles = _quantiles(level)
-            lo = res["mean"].reshape(-1, 1) - quantiles * res["sigma2"].reshape(-1, 1)
-            hi = res["mean"].reshape(-1, 1) + quantiles * res["sigma2"].reshape(-1, 1)
+            sigma = np.sqrt(res["sigma2"]).reshape(-1, 1)
+            lo = res["mean"].reshape(-1, 1) - quantiles * sigma
+            hi = res["mean"].reshape(-1, 1) + quantiles * sigma
             lo = lo[:, ::-1]
             lo = {f"lo-{l}": lo[:, i] for i, l in enumerate(reversed(level))}
             hi = {f"hi-{l}": hi[:, i] for i, l in enumerate(level)}
@@ -6733,12 +6734,9 @@ class GARCH(_TS):
                 res = self._add_predict_conformal_intervals(res, level)
             else:
                 quantiles = _quantiles(level)
-                lo = res["mean"].reshape(-1, 1) - quantiles * res["sigma2"].reshape(
-                    -1, 1
-                )
-                hi = res["mean"].reshape(-1, 1) + quantiles * res["sigma2"].reshape(
-                    -1, 1
-                )
+                sigma = np.sqrt(res["sigma2"]).reshape(-1, 1)
+                lo = res["mean"].reshape(-1, 1) - quantiles * sigma
+                hi = res["mean"].reshape(-1, 1) + quantiles * sigma
                 lo = lo[:, ::-1]
                 lo = {f"lo-{l}": lo[:, i] for i, l in enumerate(reversed(level))}
                 hi = {f"hi-{l}": hi[:, i] for i, l in enumerate(level)}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import norm
 
 # from fastcore.test import test_close, test_eq, test_fail
 from statsforecast.garch import generate_garch_data
@@ -2024,6 +2025,15 @@ class TestGARCH:
         assert_class(garch_c, x=ap, h=13, level=[90, 80], test_forward=False)
         fcst_garch_c = garch_c.forecast(ap, 13, None, None, (80, 95), True)
         np.testing.assert_array_equal(fcst_garch_c["mean"][:12], fcst_garch["mean"])
+
+    def test_garch_interval_scale(self):
+        # hi/lo = mean +/- z * sigma
+        y = self.y * 10
+        fcst = GARCH(2, 2).forecast(y, h=12, level=[95])
+        z = norm.ppf(0.975)
+        sigma = np.sqrt(fcst["sigma2"])
+        np.testing.assert_allclose((fcst["hi-95"] - fcst["mean"]) / sigma, z)
+        np.testing.assert_allclose((fcst["mean"] - fcst["lo-95"]) / sigma, z)
 
 
 # h = 100


### PR DESCRIPTION
Fixes issue reported by @mfuzalam in #1230. Prediction intervals should be given by $\text{hi/lo} =  \mu \pm z * \sigma$, not $\text{hi/lo} = \mu \pm z * \sigma^2$, as it's currently being used. 