### PR TITLE
arima: rotate xreg onto the singular directions, as R does

### DIFF
--- a/python/statsforecast/arima.py
+++ b/python/statsforecast/arima.py
@@ -635,7 +635,7 @@ def arima(
         orig_xreg = (ncxreg == 1) | (~mask[narma + np.arange(ncxreg)]).any()
         if not orig_xreg:
             _, _, vt = np.linalg.svd(xreg[(~np.isnan(xreg)).all(1)])
-            xreg = np.matmul(xreg, vt)
+            xreg = np.matmul(xreg, vt.T)
         dx = x
         dxreg = xreg
         if order[1] > 0:
@@ -942,9 +942,9 @@ def arima(
         nm += cn
         if not orig_xreg and (var is not None):
             ind = narma + np.arange(ncxreg)
-            coef[ind] = np.matmul(vt, coef[ind])
+            coef[ind] = np.matmul(vt.T, coef[ind])
             A = np.identity(narma + ncxreg)
-            A[np.ix_(ind, ind)] = vt
+            A[np.ix_(ind, ind)] = vt.T
             A = A[np.ix_(mask, mask)]
             var = np.matmul(np.matmul(A, var), A.T)
     # if no_optim:

--- a/tests/test_arima.py
+++ b/tests/test_arima.py
@@ -912,7 +912,7 @@ def test_issue_649(capsys):
     y = np.array(42 * [100] + [119, 525])
     AutoARIMA(season_length=12, trace=True).fit(y)
     captured = capsys.readouterr()
-    expected_output = """ARIMA(2,0,2)(1,0,1)[12] with non-zero mean : inf
+    expected_output = """ARIMA(2,0,2)(1,0,1)[12] with non-zero mean : 505.8834
 ARIMA(0,0,0)            with non-zero mean : 494.2237
 ARIMA(1,0,0)(1,0,0)[12] with non-zero mean : 496.9135
 ARIMA(0,0,1)(0,0,1)[12] with non-zero mean : 496.7905


### PR DESCRIPTION
## What

`arima()` mirrors R's `orig.xreg` handling: when a multi-column `xreg` has all-free coefficients, R rotates it by `S$v` before fitting so the regressors are decorrelated. numpy's `np.linalg.svd` returns `vt`, which is that matrix **transposed**, so translating `S$v` as `vt` rotates by the wrong matrix. This fixes the three places it appears (`arima.py:637`, `:945`, `:947`).

## Why it is (mostly) invisible

The fit and both undo steps use the same matrix, so an orthogonal reparameterisation cancels out. Checked against R on a correlated two-regressor `ARIMA(1,0,0)`:

| | ar1 | intercept | x1 | x2 |
|---|---|---|---|---|
| R | 0.4137301 | 4.6348616 | 2.0529427 | -1.7308965 |
| before | 0.41373177 | 4.63487285 | 2.05294542 | -1.73090278 |
| after | 0.41373184 | 4.63487299 | 2.05294547 | -1.73090284 |

Coefficients agree to 7 decimals, standard errors to 6, before and after.

## Why it still matters

What is lost is the point of the rotation. On a near-collinear design:

| rotation | max off-diagonal of Gram matrix | column norms |
|---|---|---|
| `X @ vt.T` (R) | `3.0e-14` | `[15.80, 6.30, 1.85e-09]` — the singular values |
| `X @ vt` (before) | `70.06` | `[4.98, 14.14, 8.04]` — unrelated to the spectrum |

Two consequences. Fitting happens in a worse-conditioned basis than intended. And the singular values do not describe the rotated columns, which is what a rank check on the `xreg` would need — see the collinearity issue filed alongside this.

## Test change

Better conditioning changes what the optimizer reaches, so `ARIMA(2,0,2)(1,0,1)[12]` on the issue-649 series now scores `505.8834` instead of being rejected. R's `auto.arima` scores it `505.8942`, so the pinned `inf` recorded a deviation from R rather than the intended behaviour; the expectation moves with it.

## Testing

Full non-distributed suite: 597 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YXn1fursQmqpMazreQccZ